### PR TITLE
feat: `exit` command

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,4 +1,3 @@
-import { assert } from "https://deno.land/std@0.147.0/testing/asserts.ts";
 import $, { build$, CommandBuilder } from "./mod.ts";
 import { assertEquals, assertRejects, assertThrows } from "./src/deps.test.ts";
 import { Buffer, path } from "./src/deps.ts";

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,3 +1,4 @@
+import { assert } from "https://deno.land/std@0.147.0/testing/asserts.ts";
 import $, { build$, CommandBuilder } from "./mod.ts";
 import { assertEquals, assertRejects, assertThrows } from "./src/deps.test.ts";
 import { Buffer, path } from "./src/deps.ts";
@@ -174,6 +175,43 @@ Deno.test("sleep command", async () => {
   const end = performance.now();
   assertEquals(result, "1");
   assertEquals(end - start > 190, true);
+});
+
+Deno.test("exit command", async() => {
+  {
+    const result = await $`exit`.noThrow();
+    assertEquals(result.code, 1);
+  }
+  {
+    const result = await $`exit 0`.noThrow();
+    assertEquals(result.code, 0);
+  }
+  {
+    const result = await $`exit 255`.noThrow();
+    assertEquals(result.code, 255);
+  }
+  {
+    const result = await $`exit 256`.noThrow();
+    assertEquals(result.code, 0);
+  }
+  {
+    const result = await $`exit 257`.noThrow();
+    assertEquals(result.code, 1);
+  }
+  {
+    const result = await $`exit -1`.noThrow();
+    assertEquals(result.code, 255);
+  }
+  {
+    const result = await $`exit zardoz`.noThrow();
+    assertEquals(result.code, 2);
+    assertEquals(result.stderr, "exit: numeric argument required.\n");
+  }
+  {
+    const result = await $`exit 1 1`.noThrow();
+    assertEquals(result.code, 2);
+    assertEquals(result.stderr, "exit: too many arguments\n");  
+  }
 });
 
 Deno.test("should provide result from one command to another", async () => {

--- a/src/commands/exit.ts
+++ b/src/commands/exit.ts
@@ -1,0 +1,32 @@
+import { ShellPipeWriter } from "../pipes.ts";
+import { ExitExecuteResult } from "../result.ts";
+
+export async function exitCommand(args: string[], stderr: ShellPipeWriter): Promise<ExitExecuteResult> {
+  try {
+    const code = parseArgs(args);
+    return {
+      kind: 'exit',
+      code,
+    }
+  } catch (err) {
+    await stderr.writeLine(`exit: ${err?.message ?? err}`);
+    // impl. note: bash returns 2 on exit parse failure, deno_task_shell returns 1
+    return {
+      kind: 'exit',
+      code: 2,
+    };
+  }
+}
+
+function parseArgs(args: string[]) {
+  // no explicit code defaults to 1
+  if (args.length === 0) return 1;
+  if (args.length > 1) throw new Error('too many arguments');
+  const exitCode = parseInt(args[0], 10);
+  if (isNaN(exitCode)) throw new Error('numeric argument required.');
+  if (exitCode < 0) {
+    const code = -exitCode % 256;
+    return 256 - code;
+  }
+  return exitCode % 256;
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,6 +1,7 @@
 import { instantiate } from "../lib/rs_lib.generated.js";
 import { cdCommand } from "./commands/cd.ts";
 import { echoCommand } from "./commands/echo.ts";
+import { exitCommand } from "./commands/exit.ts";
 import { exportCommand } from "./commands/export.ts";
 import { sleepCommand } from "./commands/sleep.ts";
 import { DenoWhichRealEnvironment, path, which } from "./deps.ts";
@@ -522,6 +523,8 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
     return await cdCommand(context.getCwd(), commandArgs.slice(1), context.stderr);
   } else if (commandArgs[0] === "echo") {
     return await echoCommand(commandArgs.slice(1), context.stdout);
+  } else if (commandArgs[0] === 'exit') {
+    return await exitCommand(commandArgs.slice(1), context.stderr);
   } else if (commandArgs[0] === "export") {
     return await exportCommand(commandArgs.slice(1));
   } else if (commandArgs[0] === "sleep") {


### PR DESCRIPTION
I just wanted to say this is a great little project, thanks for contributing it!  It's coming in quite handy for a little project I am working on for migrating from `go-task`.

I came across a bug while trying to use `cd` -- it assumes that all paths are relative to the CWD, which obviously leads to some weird behaviour when you do feed it absolute paths.  I just added a quick check to leave absolute paths alone if provided, and that seems to do the trick.

I also needed `exit` and various incantations of `test` for my use case, so I added them as well.  I know its a new project and that you're planning on adding support for more of the commands within `deno_task_shell` at some point, so maybe these aren't exactly what you're looking for.. but they fit the bill for my use case, so I thought I might as well PR them back as well just in case anyone else needs them in the meantime.

I apologize for being lazy and not adding tests; I just kind of made sure it worked for what I needed.  I am ok with adding some tests as well if you'd like, but it may take me a couple of days.

Thanks again for the cool project!