### PR TITLE
fix: support absolute paths in `cd` command

### DIFF
--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,4 +1,4 @@
-import { path } from "../deps.ts";
+import { resolvePath } from "../common.ts";
 import { ShellPipeWriter } from "../pipes.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
 
@@ -21,7 +21,7 @@ export async function cdCommand(cwd: string, args: string[], stderr: ShellPipeWr
 
 async function executeCd(cwd: string, args: string[]) {
   const arg = parseArgs(args);
-  const result = path.resolve(path.join(cwd, arg));
+  const result = resolvePath(cwd, arg);
   if (!await isDirectory(result)) {
     throw new Error(`${result}: Not a directory`);
   }

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,4 +1,5 @@
-import { delayToIterator, delayToMs, formatMillis } from "./common.ts";
+import { delayToIterator, delayToMs, formatMillis, resolvePath } from "./common.ts";
+import { path } from "./deps.ts";
 import { assertEquals } from "./deps.test.ts";
 
 Deno.test("should get delay value", () => {
@@ -34,4 +35,19 @@ Deno.test("should format milliseconds", () => {
   assertEquals(formatMillis(1000), "1 second");
   assertEquals(formatMillis(2000), "2 seconds");
   assertEquals(formatMillis(1500), "1.5 seconds");
+});
+
+Deno.test("should resolve absolute and relative paths", () => {
+  assertEquals(
+    resolvePath("/some/path", "./below"),
+    path.resolve("/some/path/below"),
+  );
+  assertEquals(
+    resolvePath("/some/path", "../above"),
+    path.resolve("/some/above"),
+  );
+  assertEquals(
+    resolvePath("/some/path", "/some/other/path"),
+    path.resolve("/some/other/path"),
+  )
 });

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -49,5 +49,5 @@ Deno.test("should resolve absolute and relative paths", () => {
   assertEquals(
     resolvePath("/some/path", "/some/other/path"),
     path.resolve("/some/other/path"),
-  )
+  );
 });

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,5 @@
+import { path } from "./deps.ts";
+
 /**
  * Delay used for certain actions.
  *
@@ -56,4 +58,8 @@ export function filterEmptyRecordValues<TValue>(record: Record<string, TValue | 
     }
   }
   return result;
+}
+
+export function resolvePath(cwd: string, arg: string) {
+  return path.resolve(path.isAbsolute(arg) ? arg : path.join(cwd, arg));
 }


### PR DESCRIPTION
Simple bug fix to allow the `cd` command to support absolute paths, instead of only paths relative to the CWD.

@dsherret I'll do the `~` thing in a separate PR; tests will obviously be a lot more involved given differences in platform.