### PR TITLE
feat: add `test` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ Currently implemented (though not every option is supported):
 - [`cd`](https://man7.org/linux/man-pages/man1/cd.1p.html) - Change directory command.
   - Note that shells don't export their environment by default.
 - [`echo`](https://man7.org/linux/man-pages/man1/echo.1.html) - Echo command.
+- [`exit`](https://man7.org/linux/man-pages/man1/exit.1p.html) - Exit command.
 - [`sleep`](https://man7.org/linux/man-pages/man1/sleep.1.html) - Sleep command.
+- [`test`](https://man7.org/linux/man-pages/man1/test.1.html) - Test command.
 - More to come. Will try to get a similar list as https://deno.land/manual/tools/task_runner#built-in-commands
 
 ## Builder APIs

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,7 +1,6 @@
-import { assertExists } from "https://deno.land/std@0.147.0/testing/asserts.ts";
 import $, { build$, CommandBuilder } from "./mod.ts";
 import { assertEquals, assertRejects, assertThrows } from "./src/deps.test.ts";
-import { Buffer, fs, path, which } from "./src/deps.ts";
+import { Buffer, path } from "./src/deps.ts";
 
 Deno.test("should get stdout by default", async () => {
   const output = await $`echo 5`;

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -220,12 +220,12 @@ Deno.test("test command", async (t) => {
       const result = await $`test -L linked.dat`.noThrow();
       assertEquals(result.code, 0, "should be a symlink");
     });
-    await t.step("test -L on a non-symlink", async () => {
-      const result = await $`test -L zero.dat`.noThrow();
-      assertEquals(result.code, 1, "should fail as not a symlink");
-      assertEquals(result.stderr, "");    
-    });
   }
+  await t.step("test -L on a non-symlink", async () => {
+    const result = await $`test -L zero.dat`.noThrow();
+    assertEquals(result.code, 1, "should fail as not a symlink");
+    assertEquals(result.stderr, "");    
+  });
   await t.step("should error on unsupported test type", async () => {
     const result = await $`test -z zero.dat`.noThrow();
     assertEquals(result.code, 2, "should have exit code 2");

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -223,6 +223,21 @@ Deno.test("test command", async (t) => {
   //   assertEquals(result.code, 1, "should fail as not a symlink");
   //   assertEquals(result.stderr, "");    
   // });
+  await t.step("should error on unsupported test type", async () => {
+    const result = await $`test -z zero.dat`.noThrow();
+    assertEquals(result.code, 2, "should have exit code 2");
+    assertEquals(result.stderr, "test: unsupported test type\n");
+  });
+  await t.step("should error with not enough arguments", async() => {
+    const result = await $`test`.noThrow();
+    assertEquals(result.code, 2, "should have exit code 2");
+    assertEquals(result.stderr, "test: expected 2 arguments\n");
+  });
+  await t.step("should error with too many arguments", async() => {
+    const result = await $`test -f a b c`.noThrow();
+    assertEquals(result.code, 2, "should have exit code 2");
+    assertEquals(result.stderr, "test: expected 2 arguments\n");
+  });
   
   // await Deno.remove('linked.dat');
   await Deno.remove('zero.dat');

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -180,7 +180,9 @@ Deno.test("sleep command", async () => {
 Deno.test("test command", async (t) => {
   await Deno.writeFile('zero.dat', new Uint8Array());
   await Deno.writeFile('non-zero.dat', new Uint8Array([242]));
-  //await Deno.symlink('zero.dat', 'linked.dat');
+  if (Deno.build.os !== 'windows') {
+    await Deno.symlink('zero.dat', 'linked.dat');
+  }
   
   await t.step("test -e", async () => {
     const result = await $`test -e zero.dat`.noThrow();
@@ -214,15 +216,17 @@ Deno.test("test command", async (t) => {
     assertEquals(result.code, 1, "should fail as file is zero-sized");
     assertEquals(result.stderr, "");
   });
-  // await t.step("test -L", async () => {
-  //   const result = await $`test -L linked.dat`.noThrow();
-  //   assertEquals(result.code, 0, "should be a symlink");
-  // });
-  // await t.step("test -L on a non-symlink", async () => {
-  //   const result = await $`test -L zero.dat`.noThrow();
-  //   assertEquals(result.code, 1, "should fail as not a symlink");
-  //   assertEquals(result.stderr, "");    
-  // });
+  if (Deno.build.os !== 'windows') {
+    await t.step("test -L", async () => {
+      const result = await $`test -L linked.dat`.noThrow();
+      assertEquals(result.code, 0, "should be a symlink");
+    });
+    await t.step("test -L on a non-symlink", async () => {
+      const result = await $`test -L zero.dat`.noThrow();
+      assertEquals(result.code, 1, "should fail as not a symlink");
+      assertEquals(result.stderr, "");    
+    });
+  }
   await t.step("should error on unsupported test type", async () => {
     const result = await $`test -z zero.dat`.noThrow();
     assertEquals(result.code, 2, "should have exit code 2");
@@ -238,8 +242,30 @@ Deno.test("test command", async (t) => {
     assertEquals(result.code, 2, "should have exit code 2");
     assertEquals(result.stderr, "test: expected 2 arguments\n");
   });
-  
-  // await Deno.remove('linked.dat');
+  await t.step("should work with boolean: pass && ..", async () => {
+    const result = await $`test -f zero.dat && echo yup`.noThrow();
+    assertEquals(result.code, 0);
+    assertEquals(result.stdout, "yup\n");
+  });
+  await t.step("should work with boolean: fail && ..", async () => {
+    const result = await $`test -f ${Deno.cwd()} && echo nope`.noThrow();
+    assertEquals(result.code, 1), "should have exit code 1";
+    assertEquals(result.stdout, "");
+  });
+  await t.step("should work with boolean: pass || ..", async () => {
+    const result = await $`test -f zero.dat || echo nope`.noThrow();
+    assertEquals(result.code, 0);
+    assertEquals(result.stdout, "");
+  });
+  await t.step("should work with boolean: fail || ..", async () => {
+    const result = await $`test -f ${Deno.cwd()} || echo yup`.noThrow();
+    assertEquals(result.code, 0);
+    assertEquals(result.stdout, "yup\n");
+  });
+
+  if (Deno.build.os !== 'windows') {
+    await Deno.remove('linked.dat');
+  }
   await Deno.remove('zero.dat');
   await Deno.remove('non-zero.dat');
 });

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,0 +1,65 @@
+import { resolvePath } from "../common.ts";
+import { fs } from "../deps.ts";
+import { ShellPipeWriter } from "../pipes.ts";
+import { ExecuteResult, resultFromCode } from "../result.ts";
+
+export async function testCommand(cwd: string, args: string[], stderr: ShellPipeWriter): Promise<ExecuteResult> {
+  try {
+    const [testFlag, testPath] = parseArgs(cwd, args);
+    let result;
+    switch (testFlag) {
+      case '-f':
+        result = stat(testPath, info => info.isFile);
+        break;
+
+      case '-d':
+        result = stat(testPath, info => info.isDirectory);
+        break;
+
+      case '-e':
+        result = fs.exists(testPath);
+        break;
+
+      case '-s':
+        result = stat(testPath, info => info.size > 0);
+        break;
+
+      case '-L':
+        result = stat(testPath, info => info.isSymlink);
+        break;
+
+      default:
+        throw new Error('unsupported test type');
+    }
+    return resultFromCode(await result ? 0 : 1);
+  } catch (err) {
+    await stderr.writeLine(`test: ${err?.message ?? err}`);
+    // bash test returns 2 on error, e.g. -bash: test: -8: unary operator expected
+    return resultFromCode(2);
+  }
+}
+
+function parseArgs(cwd: string, args: string[]) {
+  if (args.length !== 2) {
+    throw new Error("expected 2 arguments");
+  }
+
+  if (args[0] == null || !args[0].startsWith('-')) {
+    throw new Error('missing test type flag');
+  }
+
+  return [args[0], resolvePath(cwd, args[1])];
+}
+
+async function stat(path: string, test: (info: Deno.FileInfo) => boolean) {
+  try {
+    const info = await Deno.stat(path);
+    return test(info);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return false;
+    } else {
+      throw err;
+    }
+  }
+}

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -8,28 +8,28 @@ export async function testCommand(cwd: string, args: string[], stderr: ShellPipe
     const [testFlag, testPath] = parseArgs(cwd, args);
     let result;
     switch (testFlag) {
-      case '-f':
+      case "-f":
         result = stat(testPath, info => info.isFile);
         break;
 
-      case '-d':
+      case "-d":
         result = stat(testPath, info => info.isDirectory);
         break;
 
-      case '-e':
+      case "-e":
         result = fs.exists(testPath);
         break;
 
-      case '-s':
+      case "-s":
         result = stat(testPath, info => info.size > 0);
         break;
 
-      case '-L':
+      case "-L":
         result = stat(testPath, info => info.isSymlink);
         break;
 
       default:
-        throw new Error('unsupported test type');
+        throw new Error("unsupported test type");
     }
     return resultFromCode(await result ? 0 : 1);
   } catch (err) {
@@ -44,8 +44,8 @@ function parseArgs(cwd: string, args: string[]) {
     throw new Error("expected 2 arguments");
   }
 
-  if (args[0] == null || !args[0].startsWith('-')) {
-    throw new Error('missing test type flag');
+  if (args[0] == null || !args[0].startsWith("-")) {
+    throw new Error("missing test type flag");
   }
 
   return [args[0], resolvePath(cwd, args[1])];

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -53,7 +53,7 @@ function parseArgs(cwd: string, args: string[]) {
 
 async function stat(path: string, test: (info: Deno.FileInfo) => boolean) {
   try {
-    const info = await Deno.stat(path);
+    const info = await Deno.lstat(path);
     return test(info);
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,5 @@
+import { path } from "./deps.ts";
+
 /**
  * Delay used for certain actions.
  *
@@ -56,4 +58,9 @@ export function filterEmptyRecordValues<TValue>(record: Record<string, TValue | 
     }
   }
   return result;
+}
+
+// TODO remove this once https://github.com/dsherret/dax/pull/5 is merged
+export function resolvePath(cwd: string, arg: string) {
+  return path.resolve(path.isAbsolute(arg) ? arg : path.join(cwd, arg));
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,6 +3,7 @@ import { cdCommand } from "./commands/cd.ts";
 import { echoCommand } from "./commands/echo.ts";
 import { exportCommand } from "./commands/export.ts";
 import { sleepCommand } from "./commands/sleep.ts";
+import { testCommand } from "./commands/test.ts";
 import { DenoWhichRealEnvironment, path, which } from "./deps.ts";
 import { ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind } from "./pipes.ts";
 import { EnvChange, ExecuteResult, resultFromCode } from "./result.ts";
@@ -526,6 +527,8 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
     return await exportCommand(commandArgs.slice(1));
   } else if (commandArgs[0] === "sleep") {
     return await sleepCommand(commandArgs.slice(1), context.stderr);
+  } else if (commandArgs[0] === "test") {
+    return await testCommand(context.getCwd(), commandArgs.slice(1), context.stderr);
   } else {
     const commandPath = await resolveCommand(commandArgs[0], context);
     const p = Deno.run({


### PR DESCRIPTION
This PR adds some limited support for a `test` command:

* `test -e <arg>` - argument exists
* `test -f <arg>` - argument is a regular file (not a directory or symlink)
* `test -d <arg>` - argument is a directory
* `test -s <arg>` - argument is non-zero sized
* `test -L <arg>` - argument is a symlink

@dsherret I could use some guidance on the symlink tests -- I have them ~commented out~ excluded on Windows for the moment as apparently you need Administrative rights to create a symlink:

```
test command => dax/mod.test.ts:180:6
error: Error: A required privilege is not held by the client. (os error 1314), symlink 'zero.dat' -> 'linked.dat'
  await Deno.symlink('zero.dat', 'linked.dat');
  ^
    at async Object.symlink (deno:runtime/js/30_fs.js:367:5)
    at async file:///C:/ ... /dax/mod.test.ts:183:3
```

I am guessing it wouldn't be a problem for GH actions, but I didn't want to assume that was the only place tests would need/want to be run without issues.

I should also note that I've (temporarily) got the `resolvePath` changes that are included in #5 here as I more or less just kept the code the same when I split it off.  My assumption is that would merge first and then I can just update this branch afterward.