### PR TITLE
feat: support for custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Currently implemented (though not every option is supported):
 - [`test`](https://man7.org/linux/man-pages/man1/test.1.html) - Test command.
 - More to come. Will try to get a similar list as https://deno.land/manual/tools/task_runner#built-in-commands
 
+You can also register your own commands with the shell parser (see below).
+
 ## Builder APIs
 
 The builder APIs are what the library uses internally and they're useful for scenarios where you want to re-use some setup state. They're immutable so every function call returns a new object (which is the same thing that happens with the objects returned from `$` and `$.request`).
@@ -259,6 +261,18 @@ const result2 = await otherBuilder
   .spawn();
 ```
 
+You can also register your own custom commands using the `registerCommand` or `registerCommands` methods:
+
+```ts
+const commandBuilder = new CommandBuilder()
+  .registerCommand("true" => () => { kind: "continue", code: 0 });
+
+const result = await commandBuilder
+  // now includes the 'true' command
+  .command("true && echo yay")
+  .spawn();
+```
+
 ### `RequestBuilder`
 
 `RequestBuilder` can be used for building up requests similar to `$.request`:
@@ -278,7 +292,7 @@ const result = await requestBuilder
 
 ### Custom `$`
 
-You may wish to create your own `$` function that has a certain setup context (for example, a defined environment variable or cwd). You may do this by using the exported `build$` with `CommandBuilder` and/or `RequestBuilder`, which is what the main default exported `$` function uses internally to build itself:
+You may wish to create your own `$` function that has a certain setup context (for example, custom commands, a defined environment variable or cwd). You may do this by using the exported `build$` with `CommandBuilder` and/or `RequestBuilder`, which is what the main default exported `$` function uses internally to build itself:
 
 ```ts
 import {

--- a/README.md
+++ b/README.md
@@ -265,7 +265,10 @@ You can also register your own custom commands using the `registerCommand` or `r
 
 ```ts
 const commandBuilder = new CommandBuilder()
-  .registerCommand("true" => () => { kind: "continue", code: 0 });
+  .registerCommand(
+    "true",
+    () => Promise.resolve({ kind: "continue", code: 0 }),
+  );
 
 const result = await commandBuilder
   // now includes the 'true' command

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -176,7 +176,7 @@ Deno.test("sleep command", async () => {
   assertEquals(end - start > 190, true);
 });
 
-Deno.test("should support custom command handlers", async (t) => {
+Deno.test("should support custom command handlers", async () => {
   const builder = new CommandBuilder()
     .handle('zardoz-speaks', async (context, args) => {
       if (args.length != 1) {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -241,11 +241,11 @@ Deno.test("should not allow invalid command names", async () => {
 });
 
 Deno.test("should unregister commands", async () => {
-  const builder = new CommandBuilder().unregisterCommand('cd').noThrow();
+  const builder = new CommandBuilder().unregisterCommand("export").noThrow();
   await assertRejects(
-    async () => await builder.command('cd somewhere'),
+    async () => await builder.command("export somewhere"),
     Error,
-    "Command not found: cd"
+    "Command not found: export"
   );
 });
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -241,7 +241,7 @@ Deno.test("should not allow invalid command names", async () => {
 });
 
 Deno.test("should unregister commands", async () => {
-  const builder = new CommandBuilder().unregisterCommand('cd');
+  const builder = new CommandBuilder().unregisterCommand('cd').noThrow();
   await assertRejects(
     async () => await builder.command('cd somewhere'),
     Error,

--- a/mod.ts
+++ b/mod.ts
@@ -4,7 +4,17 @@ import { colors, fs, path, which, whichSync } from "./src/deps.ts";
 import { RequestBuilder } from "./src/request.ts";
 
 export { CommandBuilder, CommandResult } from "./src/command.ts";
+export type { CommandContext, CommandHandler, CommandPipeWriter } from "./src/command_handler.ts";
 export { RequestBuilder, RequestResult } from "./src/request.ts";
+export type {
+  CdChange,
+  ContinueExecuteResult,
+  EnvChange,
+  ExecuteResult,
+  ExitExecuteResult,
+  SetEnvVarChange,
+  SetShellVarChange,
+} from "./src/result.ts";
 
 /**
  * Cross platform shell tools for Deno inspired by [zx](https://github.com/google/zx).

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,3 +1,4 @@
+import { CommandHandler } from "./command_handler.ts";
 import { cdCommand } from "./commands/cd.ts";
 import { echoCommand } from "./commands/echo.ts";
 import { exitCommand } from "./commands/exit.ts";
@@ -14,7 +15,7 @@ import {
   ShellPipeWriter,
   ShellPipeWriterKind,
 } from "./pipes.ts";
-import { CommandHandler, parseArgs, spawn } from "./shell.ts";
+import { parseArgs, spawn } from "./shell.ts";
 
 type BufferStdio = "inherit" | "null" | Buffer;
 
@@ -141,13 +142,11 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
    * Register multilple commands.
    */
   registerCommands(commands: Record<string, CommandHandler>) {
-    const names = Object.keys(commands);
-    for (let n = 0; n < names.length; n += 1) {
-      validateCommandName(names[n]);
+    let command: CommandBuilder = this;
+    for (const [key, value] of Object.entries(commands)) {
+      command = command.registerCommand(key, value);
     }
-    return this.#newWithState(state => {
-      Object.assign(state.commands, commands);
-    });
+    return command;
   }
 
   /**
@@ -156,7 +155,7 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
   unregisterCommand(command: string) {
     return this.#newWithState(state => {
       delete state.commands[command];
-    })
+    });
   }
 
   /** Sets the raw command to execute. */

--- a/src/command_handler.ts
+++ b/src/command_handler.ts
@@ -1,0 +1,19 @@
+import { ExecuteResult } from "./result.ts";
+
+export type CommandPipeReader = "inherit" | "null" | Deno.Reader;
+
+export interface CommandPipeWriter extends Deno.Writer {
+  write(p: Uint8Array): Promise<number>;
+  writeText(text: string): Promise<void>;
+  writeLine(text: string): Promise<void>;
+}
+
+export interface CommandContext {
+  get args(): string[];
+  get cwd(): string;
+  get stdin(): CommandPipeReader;
+  get stdout(): CommandPipeWriter;
+  get stderr(): CommandPipeWriter;
+}
+
+export type CommandHandler = (context: CommandContext) => Promise<ExecuteResult>;

--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,11 +1,10 @@
+import { CommandContext } from "../command_handler.ts";
 import { resolvePath } from "../common.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
-import { Context } from "../shell.ts";
 
-export async function cdCommand(context: Context, args: string[]): Promise<ExecuteResult> {
-  const cwd = context.getCwd();
+export async function cdCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
-    const dir = await executeCd(cwd, args);
+    const dir = await executeCd(context.cwd, context.args);
     return {
       code: 0,
       kind: "continue",

--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,8 +1,9 @@
 import { resolvePath } from "../common.ts";
-import { ShellPipeWriter } from "../pipes.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
+import { Context } from "../shell.ts";
 
-export async function cdCommand(cwd: string, args: string[], stderr: ShellPipeWriter): Promise<ExecuteResult> {
+export async function cdCommand(context: Context, args: string[]): Promise<ExecuteResult> {
+  const cwd = context.getCwd();
   try {
     const dir = await executeCd(cwd, args);
     return {
@@ -14,7 +15,7 @@ export async function cdCommand(cwd: string, args: string[], stderr: ShellPipeWr
       }],
     };
   } catch (err) {
-    await stderr.writeLine(`cd: ${err?.message ?? err}`);
+    await context.stderr.writeLine(`cd: ${err?.message ?? err}`);
     return resultFromCode(1);
   }
 }

--- a/src/commands/echo.ts
+++ b/src/commands/echo.ts
@@ -1,7 +1,7 @@
+import { CommandContext } from "../command_handler.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
-import { Context } from "../shell.ts";
 
-export async function echoCommand(context: Context, args: string[]): Promise<ExecuteResult> {
-  await context.stdout.writeLine(args.join(" "));
+export async function echoCommand(context: CommandContext): Promise<ExecuteResult> {
+  await context.stdout.writeLine(context.args.join(" "));
   return resultFromCode(0);
 }

--- a/src/commands/echo.ts
+++ b/src/commands/echo.ts
@@ -1,7 +1,7 @@
-import { ShellPipeWriter } from "../pipes.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
+import { Context } from "../shell.ts";
 
-export async function echoCommand(args: string[], stdout: ShellPipeWriter): Promise<ExecuteResult> {
-  await stdout.writeLine(args.join(" "));
+export async function echoCommand(context: Context, args: string[]): Promise<ExecuteResult> {
+  await context.stdout.writeLine(args.join(" "));
   return resultFromCode(0);
 }

--- a/src/commands/exit.ts
+++ b/src/commands/exit.ts
@@ -1,13 +1,13 @@
+import { CommandContext } from "../command_handler.ts";
 import { ExitExecuteResult } from "../result.ts";
-import { Context } from "../shell.ts";
 
-export async function exitCommand(context: Context, args: string[]): Promise<ExitExecuteResult> {
+export async function exitCommand(context: CommandContext): Promise<ExitExecuteResult> {
   try {
-    const code = parseArgs(args);
+    const code = parseArgs(context.args);
     return {
       kind: "exit",
       code,
-    }
+    };
   } catch (err) {
     await context.stderr.writeLine(`exit: ${err?.message ?? err}`);
     // impl. note: bash returns 2 on exit parse failure, deno_task_shell returns 1

--- a/src/commands/exit.ts
+++ b/src/commands/exit.ts
@@ -1,18 +1,18 @@
-import { ShellPipeWriter } from "../pipes.ts";
 import { ExitExecuteResult } from "../result.ts";
+import { Context } from "../shell.ts";
 
-export async function exitCommand(args: string[], stderr: ShellPipeWriter): Promise<ExitExecuteResult> {
+export async function exitCommand(context: Context, args: string[]): Promise<ExitExecuteResult> {
   try {
     const code = parseArgs(args);
     return {
-      kind: 'exit',
+      kind: "exit",
       code,
     }
   } catch (err) {
-    await stderr.writeLine(`exit: ${err?.message ?? err}`);
+    await context.stderr.writeLine(`exit: ${err?.message ?? err}`);
     // impl. note: bash returns 2 on exit parse failure, deno_task_shell returns 1
     return {
-      kind: 'exit',
+      kind: "exit",
       code: 2,
     };
   }
@@ -21,9 +21,9 @@ export async function exitCommand(args: string[], stderr: ShellPipeWriter): Prom
 function parseArgs(args: string[]) {
   // no explicit code defaults to 1
   if (args.length === 0) return 1;
-  if (args.length > 1) throw new Error('too many arguments');
+  if (args.length > 1) throw new Error("too many arguments");
   const exitCode = parseInt(args[0], 10);
-  if (isNaN(exitCode)) throw new Error('numeric argument required.');
+  if (isNaN(exitCode)) throw new Error("numeric argument required.");
   if (exitCode < 0) {
     const code = -exitCode % 256;
     return 256 - code;

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,9 +1,9 @@
+import { CommandContext } from "../command_handler.ts";
 import { EnvChange, ExecuteResult } from "../result.ts";
-import { Context } from "../shell.ts";
 
-export async function exportCommand(_: Context, args: string[]): Promise<ExecuteResult> {
+export async function exportCommand(context: CommandContext): Promise<ExecuteResult> {
   const changes: EnvChange[] = [];
-  for (const arg of args) {
+  for (const arg of context.args) {
     let equalsIndex = arg.indexOf("=");
     // ignore if it doesn't contain an equals sign
     if (equalsIndex >= 0) {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,6 +1,7 @@
 import { EnvChange, ExecuteResult } from "../result.ts";
+import { Context } from "../shell.ts";
 
-export async function exportCommand(args: string[]): Promise<ExecuteResult> {
+export async function exportCommand(_: Context, args: string[]): Promise<ExecuteResult> {
   const changes: EnvChange[] = [];
   for (const arg of args) {
     let equalsIndex = arg.indexOf("=");

--- a/src/commands/sleep.ts
+++ b/src/commands/sleep.ts
@@ -1,9 +1,9 @@
+import { CommandContext } from "../command_handler.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
-import { Context } from "../shell.ts";
 
-export async function sleepCommand(context: Context, args: string[]): Promise<ExecuteResult> {
+export async function sleepCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
-    const ms = parseArgs(args);
+    const ms = parseArgs(context.args);
     await new Promise(resolve => setTimeout(resolve, ms));
     return resultFromCode(0);
   } catch (err) {

--- a/src/commands/sleep.ts
+++ b/src/commands/sleep.ts
@@ -1,13 +1,13 @@
-import { ShellPipeWriter } from "../pipes.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
+import { Context } from "../shell.ts";
 
-export async function sleepCommand(args: string[], stderr: ShellPipeWriter): Promise<ExecuteResult> {
+export async function sleepCommand(context: Context, args: string[]): Promise<ExecuteResult> {
   try {
     const ms = parseArgs(args);
     await new Promise(resolve => setTimeout(resolve, ms));
     return resultFromCode(0);
   } catch (err) {
-    await stderr.writeLine(`sleep: ${err?.message ?? err}`);
+    await context.stderr.writeLine(`sleep: ${err?.message ?? err}`);
     return resultFromCode(1);
   }
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,11 +1,11 @@
 import { resolvePath } from "../common.ts";
 import { fs } from "../deps.ts";
-import { ShellPipeWriter } from "../pipes.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
+import { Context } from "../shell.ts";
 
-export async function testCommand(cwd: string, args: string[], stderr: ShellPipeWriter): Promise<ExecuteResult> {
+export async function testCommand(context: Context, args: string[]): Promise<ExecuteResult> {
   try {
-    const [testFlag, testPath] = parseArgs(cwd, args);
+    const [testFlag, testPath] = parseArgs(context.getCwd(), args);
     let result;
     switch (testFlag) {
       case "-f":
@@ -33,7 +33,7 @@ export async function testCommand(cwd: string, args: string[], stderr: ShellPipe
     }
     return resultFromCode(await result ? 0 : 1);
   } catch (err) {
-    await stderr.writeLine(`test: ${err?.message ?? err}`);
+    await context.stderr.writeLine(`test: ${err?.message ?? err}`);
     // bash test returns 2 on error, e.g. -bash: test: -8: unary operator expected
     return resultFromCode(2);
   }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,12 +1,12 @@
+import { CommandContext } from "../command_handler.ts";
 import { resolvePath } from "../common.ts";
 import { fs } from "../deps.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
-import { Context } from "../shell.ts";
 
-export async function testCommand(context: Context, args: string[]): Promise<ExecuteResult> {
+export async function testCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
-    const [testFlag, testPath] = parseArgs(context.getCwd(), args);
-    let result;
+    const [testFlag, testPath] = parseArgs(context.cwd, context.args);
+    let result: Promise<boolean>;
     switch (testFlag) {
       case "-f":
         result = stat(testPath, info => info.isFile);

--- a/src/deps.test.ts
+++ b/src/deps.test.ts
@@ -1,1 +1,1 @@
-export { assertEquals, assertRejects, assertThrows } from "https://deno.land/std@0.147.0/testing/asserts.ts";
+export { assert, assertEquals, assertRejects, assertThrows } from "https://deno.land/std@0.147.0/testing/asserts.ts";

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,15 +1,9 @@
 import { instantiate } from "../lib/rs_lib.generated.js";
-import { cdCommand } from "./commands/cd.ts";
-import { echoCommand } from "./commands/echo.ts";
-import { exitCommand } from "./commands/exit.ts";
-import { exportCommand } from "./commands/export.ts";
-import { sleepCommand } from "./commands/sleep.ts";
-import { testCommand } from "./commands/test.ts";
 import { DenoWhichRealEnvironment, path, which } from "./deps.ts";
 import { ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind } from "./pipes.ts";
 import { EnvChange, ExecuteResult, resultFromCode } from "./result.ts";
 
-export type CustomCommandHandler = (context: Context, args: string[]) => Promise<ExecuteResult>;
+export type CommandHandler = (context: Context, args: string[]) => Promise<ExecuteResult>;
 
 export interface SequentialList {
   items: SequentialListItem[];
@@ -204,13 +198,13 @@ class ShellEnv implements Env {
   }
 }
 
-class Context {
+export class Context {
   stdin: ShellPipeReader;
   stdout: ShellPipeWriter;
   stderr: ShellPipeWriter;
   #env: Env;
   #shellVars: Record<string, string>;
-  #commands: Record<string, CustomCommandHandler>;
+  #commands: Record<string, CommandHandler>;
   #signal: AbortSignal;
 
   constructor(opts: {
@@ -218,7 +212,7 @@ class Context {
     stdout: ShellPipeWriter;
     stderr: ShellPipeWriter;
     env: Env;
-    commands: Record<string, CustomCommandHandler>;
+    commands: Record<string, CommandHandler>;
     shellVars: Record<string, string>;
     signal: AbortSignal;
   }) {
@@ -331,7 +325,7 @@ export interface SpawnOpts {
   stdout: ShellPipeWriter;
   stderr: ShellPipeWriter;
   env: Record<string, string>;
-  customCommands: Record<string, CustomCommandHandler>;
+  commands: Record<string, CommandHandler>;
   cwd: string;
   exportEnv: boolean;
   signal: AbortSignal;
@@ -340,7 +334,7 @@ export interface SpawnOpts {
 export async function spawn(list: SequentialList, opts: SpawnOpts) {
   const context = new Context({
     env: opts.exportEnv ? new RealEnv() : new ShellEnv(opts),
-    commands: opts.customCommands,
+    commands: opts.commands,
     stdin: opts.stdin,
     stdout: opts.stdout,
     stderr: opts.stderr,
@@ -531,72 +525,49 @@ async function executeSimpleCommand(command: SimpleCommand, parentContext: Conte
   return await executeCommandArgs(commandArgs, context);
 }
 
-export function isBuiltIn(command: string) {
-  const cmd = command.toLowerCase();
-  return (cmd === "cd"
-    || cmd === "echo"
-    || cmd === "export"
-    || cmd === "sleep"
-    || cmd === "deno");
-}
-
 async function executeCommandArgs(commandArgs: string[], context: Context) {
-  if (commandArgs[0] === "cd") {
-    return await cdCommand(context.getCwd(), commandArgs.slice(1), context.stderr);
-  } else if (commandArgs[0] === "echo") {
-    return await echoCommand(commandArgs.slice(1), context.stdout);
-  } else if (commandArgs[0] === 'exit') {
-    return await exitCommand(commandArgs.slice(1), context.stderr);
-  } else if (commandArgs[0] === "export") {
-    return await exportCommand(commandArgs.slice(1));
-  } else if (commandArgs[0] === "sleep") {
-    return await sleepCommand(commandArgs.slice(1), context.stderr);
-  } else if (commandArgs[0] === "test") {
-    return await testCommand(context.getCwd(), commandArgs.slice(1), context.stderr);
-  } else {
-    // look for a user-defined command first
-    const customCommand = context.getCommand(commandArgs[0]);
-    if (customCommand != null) {
-      return await customCommand(context, commandArgs.slice(1));
-    }
+  // look for a registered command first
+  const command = context.getCommand(commandArgs[0]);
+  if (command != null) {
+    return command(context, commandArgs.slice(1));
+  }
 
-    // fall back to trying to resolve the command on the fs
-    const commandPath = await resolveCommand(commandArgs[0], context);
-    const p = Deno.run({
-      cmd: [commandPath, ...commandArgs.slice(1)],
-      cwd: context.getCwd(),
-      env: context.getEnvVars(),
-      stdin: getStdioStringValue(context.stdin),
-      stdout: getStdioStringValue(context.stdout.kind),
-      stderr: getStdioStringValue(context.stderr.kind),
-    });
-    const abortListener = () => p.kill("SIGKILL");
-    context.signal.addEventListener("abort", abortListener);
-    const completeController = new AbortController();
-    const completeSignal = completeController.signal;
-    try {
-      // ignore the result of writing to stdin because it may
-      // have not finished before the process finished
-      const _ignore = writeStdin(context.stdin, p, completeSignal);
-      const readStdoutTask = readStdOutOrErr(p.stdout, context.stdout);
-      const readStderrTask = readStdOutOrErr(p.stderr, context.stderr);
-      const [status] = await Promise.all([
-        p.status(),
-        readStdoutTask,
-        readStderrTask,
-      ]);
-      if (context.signal.aborted) {
-        return getAbortedResult();
-      } else {
-        return resultFromCode(status.code);
-      }
-    } finally {
-      completeController.abort();
-      context.signal.removeEventListener("abort", abortListener);
-      p.close();
-      p.stdout?.close();
-      p.stderr?.close();
+  // fall back to trying to resolve the command on the fs
+  const commandPath = await resolveCommand(commandArgs[0], context);
+  const p = Deno.run({
+    cmd: [commandPath, ...commandArgs.slice(1)],
+    cwd: context.getCwd(),
+    env: context.getEnvVars(),
+    stdin: getStdioStringValue(context.stdin),
+    stdout: getStdioStringValue(context.stdout.kind),
+    stderr: getStdioStringValue(context.stderr.kind),
+  });
+  const abortListener = () => p.kill("SIGKILL");
+  context.signal.addEventListener("abort", abortListener);
+  const completeController = new AbortController();
+  const completeSignal = completeController.signal;
+  try {
+    // ignore the result of writing to stdin because it may
+    // have not finished before the process finished
+    const _ignore = writeStdin(context.stdin, p, completeSignal);
+    const readStdoutTask = readStdOutOrErr(p.stdout, context.stdout);
+    const readStderrTask = readStdOutOrErr(p.stderr, context.stderr);
+    const [status] = await Promise.all([
+      p.status(),
+      readStdoutTask,
+      readStderrTask,
+    ]);
+    if (context.signal.aborted) {
+      return getAbortedResult();
+    } else {
+      return resultFromCode(status.code);
     }
+  } finally {
+    completeController.abort();
+    context.signal.removeEventListener("abort", abortListener);
+    p.close();
+    p.stdout?.close();
+    p.stderr?.close();
   }
 
   async function writeStdin(stdin: ShellPipeReader, p: Deno.Process, signal: AbortSignal) {


### PR DESCRIPTION
As mentioned in #7, it'd be nice to extend the shell parser to be able to handle additional commands as though they were built-ins/in the system path.  Here's a quick take at implementing support by means of extending the `CommandBuilder` with a `handle()` method for registering a custom command handler/callback.  This should fit in nicely with the custom builder pattern outlined in the documentation.

PR is not so much WIP as at a point where I could use some feedback:

* does this fit with the direction you want things to go?  I tried to be somewhat "non-invasive" in terms of how I implemented this, but as its a new project you may have already had ideas on how you wanted to implement this sort of thing down the road.
* not sure I like `handle`, but `command()` is obviously taken and `customCommand()` didn't feel right either.
* if you've got a few commands, one at a time would be tedious.  Maybe just take a `Record<string, CustomCommandHandler>`?