### PR TITLE
feat: inherit by default for stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ await $`echo $var1 $var2 $var3 $var4`
 await $`deno eval 'console.log(Deno.cwd());'`.cwd("./someDir");
 
 // makes a command not output anything to stdout and stderr
-// if set to "inherit" or "captured"
+// if set to "inherit" or "inheritPiped"
 await $`echo 5`.quiet();
 await $`echo 5`.quiet("stdout"); // or just stdout
 await $`echo 5`.quiet("stderr"); // or just stderr
@@ -264,7 +264,7 @@ import {
 
 const commandBuilder = new CommandBuilder()
   .cwd("./subDir")
-  .stdout("captured") // output to stdout and pipe to a buffer
+  .stdout("inheritPiped") // output to stdout and pipe to a buffer
   .noThrow();
 
 const otherBuilder = commandBuilder

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -31,8 +31,8 @@ Deno.test("should capture stdout when piped", async () => {
   assertEquals(output.stdout, "5\n");
 });
 
-Deno.test("should capture stdout when captured", async () => {
-  const output = await $`deno eval 'console.log(5);'`.stdout("captured");
+Deno.test("should capture stdout when inherited and piped", async () => {
+  const output = await $`deno eval 'console.log(5);'`.stdout("inheritPiped");
   assertEquals(output.code, 0);
   assertEquals(output.stdout, "5\n");
 });
@@ -63,8 +63,8 @@ Deno.test("should capture stderr when piped", async () => {
   assertEquals(output.stderr, "5\n");
 });
 
-Deno.test("should capture stderr when captured", async () => {
-  const output = await $`deno eval 'console.error(5);'`.stderr("captured");
+Deno.test("should capture stderr when inherited and piped", async () => {
+  const output = await $`deno eval 'console.error(5);'`.stderr("inheritPiped");
   assertEquals(output.code, 0);
   assertEquals(output.stderr, "5\n");
 });

--- a/src/command.ts
+++ b/src/command.ts
@@ -309,7 +309,7 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
 
     function getQuietKind(kind: ShellPipeWriterKind): ShellPipeWriterKind {
       switch (kind) {
-        case "captured":
+        case "inheritPiped":
         case "inherit":
           return "piped";
         case "null":
@@ -392,7 +392,7 @@ export async function parseAndSpawnCommand(state: CommandBuilderState) {
 
   const stdoutBuffer = state.stdoutKind === "inherit"
     ? "inherit"
-    : state.stdoutKind === "captured"
+    : state.stdoutKind === "inheritPiped"
     ? new CapturingBufferWriter(Deno.stderr, new Buffer())
     : state.stdoutKind === "null"
     ? "null"
@@ -407,7 +407,7 @@ export async function parseAndSpawnCommand(state: CommandBuilderState) {
   );
   const stderrBuffer = state.stderrKind === "inherit"
     ? "inherit"
-    : state.stderrKind === "captured"
+    : state.stderrKind === "inheritPiped"
     ? new CapturingBufferWriter(Deno.stderr, new Buffer())
     : state.stderrKind === "null"
     ? "null"

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -8,9 +8,9 @@ export type ShellPipeReader = "inherit" | "null" | Deno.Reader;
  * @value "inherit" - Sends the output directly to the current process' corresponding pipe (default).
  * @value "null" - Does not pipe or redirect the pipe.
  * @value "piped" - Captures the pipe without outputting.
- * @value "captured" - Captures the pipe with outputting.
+ * @value "inheritPiped" - Captures the pipe with outputting.
  */
-export type ShellPipeWriterKind = "inherit" | "null" | "piped" | "captured";
+export type ShellPipeWriterKind = "inherit" | "null" | "piped" | "inheritPiped";
 
 export class NullPipeWriter implements Deno.Writer {
   write(p: Uint8Array): Promise<number> {

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -3,7 +3,14 @@ import { Buffer, writeAll } from "./deps.ts";
 const encoder = new TextEncoder();
 
 export type ShellPipeReader = "inherit" | "null" | Deno.Reader;
-export type ShellPipeWriterKind = "inherit" | "null" | "piped" | "default";
+/**
+ * The behaviour to use for a shell pipe.
+ * @value "inherit" - Sends the output directly to the current process' corresponding pipe (default).
+ * @value "null" - Does not pipe or redirect the pipe.
+ * @value "piped" - Captures the pipe without outputting.
+ * @value "captured" - Captures the pipe with outputting.
+ */
+export type ShellPipeWriterKind = "inherit" | "null" | "piped" | "captured";
 
 export class NullPipeWriter implements Deno.Writer {
   write(p: Uint8Array): Promise<number> {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -626,7 +626,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
   }
 
   function getStdioStringValue(value: ShellPipeReader | ShellPipeWriterKind) {
-    if (value === "captured") {
+    if (value === "inheritPiped") {
       return "piped";
     } else if (value === "inherit" || value === "null" || value === "piped") {
       return value;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -626,7 +626,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
   }
 
   function getStdioStringValue(value: ShellPipeReader | ShellPipeWriterKind) {
-    if (value === "default") {
+    if (value === "captured") {
       return "piped";
     } else if (value === "inherit" || value === "null" || value === "piped") {
       return value;


### PR DESCRIPTION
This changes stdout and stderr to be inherited by default. There are several reasons for doing this:

1. It's more efficient.
1. I find myself writing a lot of commands without needing to capture the majority of the time.
1. There are now helper methods like ``const text = await `some_command`.text()``, which will automatically capture when necessary and people should prefer using those.
1. Helps keep stdout and stderr printed in order (https://github.com/dsherret/dax/issues/17)