### PR TITLE
fix: progress bars should not conflict with inherited command pipes

### DIFF
--- a/src/console/mod.ts
+++ b/src/console/mod.ts
@@ -4,7 +4,7 @@ export { logger } from "./logger.ts";
 export { maybeMultiSelect, multiSelect } from "./multiSelect.ts";
 export type { MultiSelectOption, MultiSelectOptions } from "./multiSelect.ts";
 export type { ProgressOptions } from "./progress/mod.ts";
-export { ProgressBar } from "./progress/mod.ts";
+export { isShowingProgressBars, ProgressBar } from "./progress/mod.ts";
 export { maybePrompt, prompt } from "./prompt.ts";
 export type { PromptOptions } from "./prompt.ts";
 export { maybeSelect, select } from "./select.ts";

--- a/src/console/progress/interval.ts
+++ b/src/console/progress/interval.ts
@@ -52,3 +52,7 @@ export function forceRender() {
   logger.setItems(LoggerRefreshItemKind.ProgressBars, items, size);
   lastRenderTime = Date.now();
 }
+
+export function isShowingProgressBars() {
+  return isInteractiveConsole && progressBars.length > 0;
+}

--- a/src/console/progress/mod.test.ts
+++ b/src/console/progress/mod.test.ts
@@ -10,14 +10,14 @@ Deno.test("should render when no length", () => {
       message: "Message",
       prefix: "Prefix",
     }),
-    "Prefix ⠋ Message",
+    "⠋ Prefix Message",
   );
   assertEquals(
     getOutput({
       prefix: "Prefix",
       tickCount: 1,
     }),
-    "Prefix ⠙",
+    "⠙ Prefix",
   );
   assertEquals(
     getOutput({

--- a/src/console/progress/mod.ts
+++ b/src/console/progress/mod.ts
@@ -9,6 +9,8 @@ import {
   RenderIntervalProgressBar,
 } from "./interval.ts";
 
+export { isShowingProgressBars } from "./interval.ts";
+
 /** Options for showing progress. */
 export interface ProgressOptions {
   /** Prefix message/word that will be displayed in green. */
@@ -25,7 +27,7 @@ export interface ProgressOptions {
   noClear?: boolean;
 }
 
-/** A progress bar instance. Create one of these via `$.progress({ ... })`. */
+/** A progress bar instance created via `$.progress(...)`. */
 export class ProgressBar {
   #state: RenderState;
   #pb: RenderIntervalProgressBar;
@@ -206,12 +208,10 @@ export function renderProgressBar(state: RenderState, size: ConsoleSize | undefi
     }
     return text.length > 0 ? [text] : [];
   } else if (state.length == null || state.length === 0) {
-    let text = "";
+    let text = colors.green(tickStrings[Math.abs(state.tickCount) % tickStrings.length]);
     if (state.prefix != null) {
-      text += `${colors.green(state.prefix)} `;
+      text += ` ${colors.green(state.prefix)}`;
     }
-
-    text += colors.green(tickStrings[Math.abs(state.tickCount) % tickStrings.length]);
     if (state.message != null) {
       text += ` ${state.message}`;
     }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,6 +2,7 @@ export * as colors from "https://deno.land/std@0.167.0/fmt/colors.ts";
 export * as fs from "https://deno.land/std@0.167.0/fs/mod.ts";
 export { Buffer } from "https://deno.land/std@0.167.0/io/buffer.ts";
 export * as path from "https://deno.land/std@0.167.0/path/mod.ts";
-export { readAll, writeAllSync } from "https://deno.land/std@0.167.0/streams/conversion.ts";
+export { readAll } from "https://deno.land/std@0.167.0/streams/read_all.ts";
+export { writeAllSync } from "https://deno.land/std@0.167.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
 export { RealEnvironment as DenoWhichRealEnvironment, which, whichSync } from "https://deno.land/x/which@0.2.1/mod.ts";

--- a/src/pipes.test.ts
+++ b/src/pipes.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "./deps.test.ts";
+import { Buffer } from "./deps.ts";
+import { InheritStaticTextBypassWriter } from "./pipes.ts";
+
+Deno.test("should line buffer the inherit static text bypass writer", () => {
+  const buffer = new Buffer();
+  const writer = new InheritStaticTextBypassWriter(buffer);
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  writer.writeSync(encoder.encode("1"));
+  assertEquals(decoder.decode(buffer.bytes()), "");
+  writer.writeSync(encoder.encode("\r\n2"));
+  assertEquals(decoder.decode(buffer.bytes()), "1\r\n");
+  writer.writeSync(encoder.encode("3"));
+  writer.writeSync(encoder.encode("4"));
+  assertEquals(decoder.decode(buffer.bytes()), "1\r\n");
+  writer.writeSync(encoder.encode("\n"));
+  assertEquals(decoder.decode(buffer.bytes()), "1\r\n234\n");
+  writer.writeSync(encoder.encode("5"));
+  writer.flush();
+  assertEquals(decoder.decode(buffer.bytes()), "1\r\n234\n5");
+});

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -91,7 +91,6 @@ export class InheritStaticTextBypassWriter implements Deno.WriterSync {
 
   flush() {
     const bytes = this.#buffer.bytes();
-
     logger.logAboveStaticText(() => {
       writeAllSync(this.#innerWriter, bytes);
     });

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -77,6 +77,7 @@ export class InheritStaticTextBypassWriter implements Deno.WriterSync {
   }
 
   writeSync(p: Uint8Array): number {
+    // line buffer the output so that we don't conflict with the progress bars
     const index = p.findLastIndex((v) => v === lineFeedCharCode);
     if (index === -1) {
       this.#buffer.writeSync(p);


### PR DESCRIPTION
This should just work:

```ts
const name = await $.prompt("What's your name?");

await $.progress("Running command...").with(async () => {
  // this here should work
  await $`sleep 1s && echo Hello, ${name}! && sleep 1s && echo Hello again!`;
});
```