### PR TITLE
fix: better handling for if terminal supports progress bars and selecion

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,16 +396,16 @@ await pb.with(async () => {
 
 #### Synchronous work
 
-The progress bars are updated on an interval (via `setInterval`). If you are doing a lot of synchronous work, it will start updating the progress bar on the current execution context, but this only occurs in some cases. Due to this, it's probably best to force a render where you think it would be appropriate by using the `.forceRender()` method:
+The progress bars are updated on an interval (via `setInterval`). If you are doing a lot of synchronous work the progress bars won't update. Due to this, you can force a render where you think it would be appropriate by using the `.forceRender()` method:
 
 ```ts
 const pb = $.progress("Processing Items");
 
-pb.with(() => {
+await pb.with(async () => {
   for (const item of items) {
-    doWork(item); // note this does not use `await` so we force rendering below
+    doWork(item);
     pb.increment();
-    pb.forceRender();
+    await pb.forceRender();
   }
 });
 ```

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -878,11 +878,11 @@ Deno.test("pwd: pwd", async () => {
   assertEquals(await $`pwd`.text(), Deno.cwd());
 });
 
-Deno.test("progress", () => {
+Deno.test("progress", async () => {
   const logs: string[] = [];
   $.setInfoLogger((...data) => logs.push(data.join(" ")));
   const pb = $.progress("Downloading Test");
-  pb.forceRender(); // should not throw;
+  await pb.forceRender(); // should not throw;
   assertEquals(logs, [
     "Downloading Test",
   ]);

--- a/src/console/logger.ts
+++ b/src/console/logger.ts
@@ -12,12 +12,14 @@ const refreshItems: Record<LoggerRefreshItemKind, TextItem[] | undefined> = {
 
 function setItems(kind: LoggerRefreshItemKind, items: TextItem[] | undefined, size?: ConsoleSize) {
   refreshItems[kind] = items;
-  return refresh(size);
+  refresh(size);
 }
 
-async function refresh(size?: ConsoleSize) {
-  const staticText = await getStaticText();
-  refreshWithStaticText(staticText, size);
+function refresh(size?: ConsoleSize) {
+  const staticText = getStaticTextIfCreated();
+  if (staticText) {
+    refreshWithStaticText(staticText, size);
+  }
 }
 
 function refreshWithStaticText(staticText: Awaited<ReturnType<typeof getStaticText>>, size?: ConsoleSize) {
@@ -44,7 +46,17 @@ async function logOnce(items: TextItem[], size?: ConsoleSize) {
   }, size);
 }
 
+async function ensureInitialized() {
+  await getStaticText();
+}
+
+function isInitilaized() {
+  return getStaticTextIfCreated() != null;
+}
+
 const logger = {
+  ensureInitialized,
+  isInitilaized,
   setItems,
   logOnce,
   logAboveStaticText,

--- a/src/console/utils.ts
+++ b/src/console/utils.ts
@@ -68,8 +68,7 @@ export function showCursor() {
   Deno.stderr.writeSync(encoder.encode("\x1B[?25h"));
 }
 
-const canGetConsoleSize = safeConsoleSize() != null;
-export const isOutputTty = canGetConsoleSize && Deno.isatty(Deno.stderr.rid);
+export const isOutputTty = safeConsoleSize() != null && Deno.isatty(Deno.stderr.rid);
 
 export function resultOrExit<T>(result: T | undefined): T {
   if (result == null) {


### PR DESCRIPTION
Also, breaking change on `pb.forceRender()` function and `pb.with`, which are both now fully async.

Closes #57