### PR TITLE
feat: cross platform shebang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Users on unix-based platforms often write a script like so:
 console.log("Hello there!");
 ```
 
-...which can be run on the command line by executing `./file.ts`. This doesn't work on the command line in Windows, but it does on all platforms in dax:
+...which can be executed on the command line by running `./file.ts`. This doesn't work on the command line in Windows, but it does on all platforms in dax:
 
 ```ts
 await $`./file.ts`;

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ const result = await $`echo $TEST`.env("TEST", "123").text();
 console.log(result); // 123
 ```
 
-### Custom Cross Platform Shell Commands
+### Custom cross platform shell commands
 
 Currently implemented (though not every option is supported):
 
@@ -578,6 +578,21 @@ Currently implemented (though not every option is supported):
 - More to come. Will try to get a similar list as https://deno.land/manual/tools/task_runner#built-in-commands
 
 You can also register your own commands with the shell parser (see below).
+
+### Cross platform shebang support
+
+Users on unix-based platforms often write a script like so:
+
+```ts
+#!/usr/bin/env -S deno run
+console.log("Hello there!");
+```
+
+...which can be run on the command line by executing `./file.ts`. This doesn't work on the command line in Windows, but it does on all platforms in dax:
+
+```ts
+await $`./file.ts`;
+```
 
 ## Builder APIs
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -578,6 +578,22 @@ Deno.test("command .lines()", async () => {
   assertEquals(result, ["1", "2"]);
 });
 
+Deno.test("shebang support", async () => {
+  await withTempDir(async (dir) => {
+    Deno.writeTextFileSync(
+      $.path.join(dir, "file.ts"),
+      [
+        "#!/usr/bin/env -S deno run",
+        "console.log(5);",
+      ].join("\n"),
+    );
+    const output = await $`./file.ts`
+      .cwd(dir)
+      .text();
+    assertEquals(output, "5");
+  });
+});
+
 Deno.test("basic logging test to ensure no errors", async () => {
   assertEquals($.logDepth, 0);
   $.logGroup();
@@ -720,8 +736,8 @@ Deno.test("test remove", async () => {
 
     await $`rm ${emptyDir}`;
     await $`rm ${someFile}`;
-    assertEquals($.fs.existsSync(dir + "/hello"), false);
-    assertEquals($.fs.existsSync(dir + "/a.txt"), false);
+    assertEquals($.existsSync(dir + "/hello"), false);
+    assertEquals($.existsSync(dir + "/a.txt"), false);
 
     const nonEmptyDir = dir + "/a";
     Deno.mkdirSync(nonEmptyDir + "/b", { recursive: true });
@@ -734,7 +750,7 @@ Deno.test("test remove", async () => {
     assertEquals(error.substring(0, expectedText.length), expectedText);
 
     await $`rm -r ${nonEmptyDir}`;
-    assertEquals($.fs.existsSync(nonEmptyDir), false);
+    assertEquals($.existsSync(nonEmptyDir), false);
   });
 });
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -19,7 +19,7 @@ import {
   ShellPipeWriter,
   ShellPipeWriterKind,
 } from "./pipes.ts";
-import { parseArgs, spawn } from "./shell.ts";
+import { parseCommand, spawn } from "./shell.ts";
 import { cpCommand, mvCommand } from "./commands/cp_mv.ts";
 import { isShowingProgressBars } from "./console/progress/interval.ts";
 
@@ -419,7 +419,7 @@ export async function parseAndSpawnCommand(state: CommandBuilderState) {
   }
 
   try {
-    const list = await parseArgs(state.command);
+    const list = await parseCommand(state.command);
     const code = await spawn(list, {
       stdin: state.stdin,
       stdout,

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -102,22 +102,45 @@ Deno.test("gets the executable shebang when it exists", async () => {
 
   assertEquals(
     await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=."),
-    "deno run --allow-env=PWD --allow-read=.",
+    {
+      stringSplit: true,
+      command: "deno run --allow-env=PWD --allow-read=.",
+    },
   );
   assertEquals(
     await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=.\n"),
-    "deno run --allow-env=PWD --allow-read=.",
+    {
+      stringSplit: true,
+      command: "deno run --allow-env=PWD --allow-read=.",
+    },
   );
   assertEquals(
     await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=.\ntesting\ntesting"),
-    "deno run --allow-env=PWD --allow-read=.",
+    {
+      stringSplit: true,
+      command: "deno run --allow-env=PWD --allow-read=.",
+    },
   );
   assertEquals(
     await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=.\r\ntesting\ntesting"),
-    "deno run --allow-env=PWD --allow-read=.",
+    {
+      stringSplit: true,
+      command: "deno run --allow-env=PWD --allow-read=.",
+    },
   );
   assertEquals(
     await get("#!/usr/bin/env deno run --allow-env=PWD --allow-read=.\r\ntesting\ntesting"),
+    {
+      stringSplit: false,
+      command: "deno run --allow-env=PWD --allow-read=.",
+    },
+  );
+  assertEquals(
+    await get("#!/bin/sh\r\ntesting\ntesting"),
+    undefined,
+  );
+  assertEquals(
+    await get("testing"),
     undefined,
   );
 });

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,6 +1,14 @@
-import { delayToIterator, delayToMs, formatMillis, getFileNameFromUrl, resolvePath, TreeBox } from "./common.ts";
+import {
+  delayToIterator,
+  delayToMs,
+  formatMillis,
+  getExecutableShebang,
+  getFileNameFromUrl,
+  resolvePath,
+  TreeBox,
+} from "./common.ts";
 import { assertEquals } from "./deps.test.ts";
-import { path } from "./deps.ts";
+import { Buffer, path } from "./deps.ts";
 
 Deno.test("should get delay value", () => {
   assertEquals(delayToMs(10), 10);
@@ -83,4 +91,33 @@ Deno.test("gets file name from url", () => {
   assertEquals(getFileNameFromUrl("https://deno.land/"), undefined);
   assertEquals(getFileNameFromUrl("https://deno.land/file/other"), "other");
   assertEquals(getFileNameFromUrl("https://deno.land/file/other/"), undefined);
+});
+
+Deno.test("gets the executable shebang when it exists", async () => {
+  function get(input: string) {
+    const data = new TextEncoder().encode(input);
+    const buffer = new Buffer(data);
+    return getExecutableShebang(buffer);
+  }
+
+  assertEquals(
+    await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=."),
+    "deno run --allow-env=PWD --allow-read=.",
+  );
+  assertEquals(
+    await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=.\n"),
+    "deno run --allow-env=PWD --allow-read=.",
+  );
+  assertEquals(
+    await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=.\ntesting\ntesting"),
+    "deno run --allow-env=PWD --allow-read=.",
+  );
+  assertEquals(
+    await get("#!/usr/bin/env -S deno run --allow-env=PWD --allow-read=.\r\ntesting\ntesting"),
+    "deno run --allow-env=PWD --allow-read=.",
+  );
+  assertEquals(
+    await get("#!/usr/bin/env deno run --allow-env=PWD --allow-read=.\r\ntesting\ntesting"),
+    undefined,
+  );
 });

--- a/src/common.ts
+++ b/src/common.ts
@@ -138,19 +138,30 @@ export function getFileNameFromUrl(url: string | URL) {
   return fileName?.length === 0 ? undefined : fileName;
 }
 
+/**
+ * Gets an executable shebang from the provided file path.
+ * @returns
+ * - A string with the shebang.
+ * - `undefined` if the file exists, but doesn't have a shebang.
+ * - `false` if the file does NOT exist.
+ */
 export async function getExecutableShebangFromPath(path: string) {
   try {
     const file = await Deno.open(path, { read: true });
     try {
       return await getExecutableShebang(file);
     } finally {
-      file.close();
+      try {
+        file.close();
+      } catch {
+        // ignore
+      }
     }
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {
       return false;
     }
-    return undefined;
+    throw err;
   }
 }
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,6 +1,7 @@
 export * as colors from "https://deno.land/std@0.170.0/fmt/colors.ts";
 export * as fs from "https://deno.land/std@0.170.0/fs/mod.ts";
 export { Buffer } from "https://deno.land/std@0.170.0/io/buffer.ts";
+export { BufReader } from "https://deno.land/std@0.170.0/io/buf_reader.ts";
 export * as path from "https://deno.land/std@0.170.0/path/mod.ts";
 export { readAll } from "https://deno.land/std@0.170.0/streams/read_all.ts";
 export { writeAllSync } from "https://deno.land/std@0.170.0/streams/write_all.ts";

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -142,9 +142,13 @@ Deno.test("$.request", (t) => {
     step("404", async () => {
       const request404 = new RequestBuilder()
         .url(new URL("/code/404", serverUrl));
-      assertRejects(async () => {
-        await request404.text();
-      });
+      assertRejects(
+        async () => {
+          await request404.text();
+        },
+        Error,
+        "Not Found",
+      );
 
       assertEquals(await request404.noThrow(404).blob(), undefined);
       assertEquals(await request404.noThrow(404).arrayBuffer(), undefined);
@@ -156,9 +160,13 @@ Deno.test("$.request", (t) => {
     step("500", async () => {
       const request500 = new RequestBuilder()
         .url(new URL("/code/500", serverUrl));
-      assertRejects(async () => {
-        await request500.text();
-      });
+      assertRejects(
+        async () => {
+          await request500.text();
+        },
+        Error,
+        "500",
+      );
 
       assertEquals(await request500.noThrow(500).text(), "500");
     });

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,4 +1,5 @@
 import { CommandContext, CommandHandler } from "./command_handler.ts";
+import { getExecutableShebangFromPath } from "./common.ts";
 import { DenoWhichRealEnvironment, path, which } from "./deps.ts";
 import { instantiateWithCaching } from "./lib/mod.ts";
 import { ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind } from "./pipes.ts";
@@ -336,7 +337,7 @@ export class Context {
   }
 }
 
-export async function parseArgs(command: string) {
+export async function parseCommand(command: string) {
   const { parse } = await instantiateWithCaching();
   return parse(command) as SequentialList;
 }
@@ -552,7 +553,7 @@ async function executeSimpleCommand(command: SimpleCommand, parentContext: Conte
   return await executeCommandArgs(commandArgs, context);
 }
 
-async function executeCommandArgs(commandArgs: string[], context: Context) {
+async function executeCommandArgs(commandArgs: string[], context: Context): Promise<ExecuteResult> {
   // look for a registered command first
   const command = context.getCommand(commandArgs[0]);
   if (command != null) {
@@ -560,9 +561,13 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
   }
 
   // fall back to trying to resolve the command on the fs
-  const commandPath = await resolveCommand(commandArgs[0], context);
+  const resolvedCommand = await resolveCommand(commandArgs[0], context);
+  if (resolvedCommand.kind === "shebang") {
+    return executeCommandArgs([...resolvedCommand.args, resolvedCommand.path, ...commandArgs.slice(1)], context);
+  }
+  const _assertIsPath: "path" = resolvedCommand.kind;
   const p = Deno.run({
-    cmd: [commandPath, ...commandArgs.slice(1)],
+    cmd: [resolvedCommand.path, ...commandArgs.slice(1)],
     cwd: context.getCwd(),
     env: context.getEnvVars(),
     stdin: getStdioStringValue(context.stdin),
@@ -576,7 +581,8 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
   try {
     // ignore the result of writing to stdin because it may
     // have not finished before the process finished
-    const _ignore = writeStdin(context.stdin, p, completeSignal);
+    const _ignore = writeStdin(context.stdin, p, completeSignal)
+      .catch(() => {/* ignore */});
     const readStdoutTask = readStdOutOrErr(p.stdout, context.stdout);
     const readStderrTask = readStdOutOrErr(p.stderr, context.stderr);
     const [status] = await Promise.all([
@@ -661,24 +667,51 @@ async function executeCommandArgs(commandArgs: string[], context: Context) {
   }
 }
 
-async function resolveCommand(commandName: string, context: Context) {
-  const realEnvironment = new DenoWhichRealEnvironment();
+type ResolvedCommand = ResolvedPathCommand | ResolvedShebangCommand;
+
+interface ResolvedPathCommand {
+  kind: "path";
+  path: string;
+}
+
+interface ResolvedShebangCommand {
+  kind: "shebang";
+  path: string;
+  args: string[];
+}
+
+async function resolveCommand(commandName: string, context: Context): Promise<ResolvedCommand> {
   if (commandName.includes("/") || commandName.includes("\\")) {
     if (!path.isAbsolute(commandName)) {
       commandName = path.relative(context.getCwd(), commandName);
     }
-    if (await realEnvironment.fileExists(commandName)) {
-      return commandName;
-    } else {
+    const result = await getExecutableShebangFromPath(commandName);
+    if (result === false) {
       throw new Error(`Command not found: ${commandName}`);
+    } else if (result != null) {
+      return {
+        kind: "shebang",
+        path: commandName,
+        args: await parseShebangArgs(result, context),
+      };
+    } else {
+      const _assertUndefined: undefined = result;
+      return {
+        kind: "path",
+        path: commandName,
+      };
     }
   }
 
   // always use the current executable for "deno"
   if (commandName.toUpperCase() === "DENO") {
-    return Deno.execPath();
+    return {
+      kind: "path",
+      path: Deno.execPath(),
+    };
   }
 
+  const realEnvironment = new DenoWhichRealEnvironment();
   const commandPath = await which(commandName, {
     os: Deno.build.os,
     fileExists(path: string) {
@@ -691,7 +724,41 @@ async function resolveCommand(commandName: string, context: Context) {
   if (commandPath == null) {
     throw new Error(`Command not found: ${commandName}`);
   }
-  return commandPath;
+  return {
+    kind: "path",
+    path: commandPath,
+  };
+}
+
+async function parseShebangArgs(text: string, context: Context): Promise<string[]> {
+  function throwUnsupported(): never {
+    throw new Error("Unsupported shebang. Please report this as a bug.");
+  }
+
+  // todo: move shebang parsing into deno_task_shell and investigate actual shebang parsing behaviour
+  const command = await parseCommand(text);
+  if (command.items.length !== 1) {
+    throwUnsupported();
+  }
+  const item = command.items[0];
+  if (item.sequence.kind !== "pipeline" || item.isAsync) {
+    throwUnsupported();
+  }
+  const sequence = item.sequence;
+  if (sequence.negated) {
+    throwUnsupported();
+  }
+  if (sequence.inner.kind !== "command" || sequence.inner.redirect != null) {
+    throwUnsupported();
+  }
+  const innerCommand = sequence.inner.inner;
+  if (innerCommand.kind !== "simple") {
+    throwUnsupported();
+  }
+  if (innerCommand.envVars.length > 0) {
+    throwUnsupported();
+  }
+  return await evaluateArgs(innerCommand.args, context);
 }
 
 async function evaluateArgs(args: Word[], context: Context) {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -683,8 +683,11 @@ interface ResolvedShebangCommand {
 async function resolveCommand(commandName: string, context: Context): Promise<ResolvedCommand> {
   if (commandName.includes("/") || commandName.includes("\\")) {
     if (!path.isAbsolute(commandName)) {
-      commandName = path.relative(context.getCwd(), commandName);
+      commandName = path.resolve(context.getCwd(), commandName);
     }
+    // only bother checking for a shebang when the path has a slash
+    // in it because for global commands someone on Windows likely
+    // won't have a script with a shebang in it on Windows
     const result = await getExecutableShebangFromPath(commandName);
     if (result === false) {
       throw new Error(`Command not found: ${commandName}`);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,5 +1,5 @@
 import { CommandContext, CommandHandler } from "./command_handler.ts";
-import { getExecutableShebangFromPath } from "./common.ts";
+import { getExecutableShebangFromPath, ShebangInfo } from "./common.ts";
 import { DenoWhichRealEnvironment, path, which } from "./deps.ts";
 import { instantiateWithCaching } from "./lib/mod.ts";
 import { ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind } from "./pipes.ts";
@@ -733,13 +733,17 @@ async function resolveCommand(commandName: string, context: Context): Promise<Re
   };
 }
 
-async function parseShebangArgs(text: string, context: Context): Promise<string[]> {
+async function parseShebangArgs(info: ShebangInfo, context: Context): Promise<string[]> {
   function throwUnsupported(): never {
     throw new Error("Unsupported shebang. Please report this as a bug.");
   }
 
+  if (!info.stringSplit) {
+    return [info.command];
+  }
+
   // todo: move shebang parsing into deno_task_shell and investigate actual shebang parsing behaviour
-  const command = await parseCommand(text);
+  const command = await parseCommand(info.command);
   if (command.items.length !== 1) {
     throwUnsupported();
   }


### PR DESCRIPTION
Supports shebangs the same way on all platforms:

```ts
#!/usr/bin/env -S deno run
console.log(5);
```

```ts
await $`./file.ts`; // outputs: 5
```