### PR TITLE
fix: resolve the path immediately in pipeToPath

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "./deps.ts";
+import { Buffer, path } from "./deps.ts";
 import { assertEquals, assertRejects, serve, writableStreamFromWriter } from "./deps.test.ts";
 import { RequestBuilder } from "./request.ts";
 
@@ -115,8 +115,11 @@ Deno.test("$.request", (t) => {
           .url(new URL("/text-file", serverUrl))
           .showProgress()
           .pipeToPath(testFilePath);
+        // ensure this only returns a string and not string | URL
+        // so that it's easier to work with
+        const _assertString: string = downloadedFilePath;
         assertEquals(Deno.readTextFileSync(testFilePath), "text".repeat(1000));
-        assertEquals(downloadedFilePath, testFilePath);
+        assertEquals(downloadedFilePath, path.resolve(testFilePath));
         // test default path
         Deno.chdir(Deno.makeTempDirSync()); // change path just to not download to the current dir
         const downloadedFilePath2 = await new RequestBuilder()
@@ -124,7 +127,7 @@ Deno.test("$.request", (t) => {
           .showProgress()
           .pipeToPath();
         assertEquals(Deno.readTextFileSync("text-file"), "text".repeat(1000));
-        assertEquals(downloadedFilePath2, "text-file");
+        assertEquals(downloadedFilePath2, path.resolve("text-file"));
       } finally {
         try {
           Deno.chdir(originDir);

--- a/src/request.ts
+++ b/src/request.ts
@@ -304,7 +304,7 @@ export class RequestBuilder implements PromiseLike<RequestResult> {
     // a security issue.
     // Additionally, resolve the path immediately in case the user changes their cwd
     // while the response is being fetched.
-    let filePathOrUrl = filePath ?? getFileNameFromUrlOrThrow(this.#state?.url);
+    const filePathOrUrl = filePath ?? getFileNameFromUrlOrThrow(this.#state?.url);
     filePath = path.resolve(typeof filePathOrUrl === "string" ? filePathOrUrl : path.fromFileUrl(filePathOrUrl));
     const response = await this.fetch();
     await response.pipeToPath(filePath, options);

--- a/src/request.ts
+++ b/src/request.ts
@@ -304,11 +304,14 @@ export class RequestBuilder implements PromiseLike<RequestResult> {
     // a security issue.
     // Additionally, resolve the path immediately in case the user changes their cwd
     // while the response is being fetched.
-    const filePathOrUrl = filePath ?? getFileNameFromUrlOrThrow(this.#state?.url);
-    filePath = path.resolve(typeof filePathOrUrl === "string" ? filePathOrUrl : path.fromFileUrl(filePathOrUrl));
+    filePath = resolvePathOrUrl(filePath ?? getFileNameFromUrlOrThrow(this.#state?.url));
     const response = await this.fetch();
     await response.pipeToPath(filePath, options);
     return filePath;
+
+    function resolvePathOrUrl(pathOrUrl: string | URL) {
+      return path.resolve(typeof pathOrUrl === "string" ? pathOrUrl : path.fromFileUrl(pathOrUrl));
+    }
 
     function getFileNameFromUrlOrThrow(url: string | URL | undefined) {
       const fileName = url == null ? undefined : getFileNameFromUrl(url);


### PR DESCRIPTION
Just noticed this while looking at the past review. I think it would be better to resolve the path immediately in case someone changes the cwd while the fetch is running.