### PR TITLE
feat(request): pipeToPath - support providing single WriteFileOptions argument

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -141,7 +141,6 @@ Deno.test("$.request", (t) => {
                 .pipeToPath({ createNew: true });
             },
             Deno.errors.AlreadyExists,
-            "The file exists.",
           );
         }
       } finally {


### PR DESCRIPTION
Also, cancel request body when pipeToPath throws.