### PR TITLE
feat: add `$.commandExists`, `$.dedent`, and `$.stripAnsi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,26 @@ await $.withRetries({
 });
 ```
 
+"Dedent" or remove leading whitespace from a string:
+
+```ts
+console.log($.dedent(`
+    This line will appear without any indentation.
+      * This list will appear with 2 spaces more than previous line.
+      * As will this line.
+
+    Empty lines (like the one above) will not affect the common indentation.
+  `));
+```
+
+```
+This line will appear without any indentation.
+  * This list will appear with 2 spaces more than previous line.
+  * As will this line.
+
+Empty lines (like the one above) will not affect the common indentation.
+```
+
 Re-export of deno_std's path:
 
 ```ts
@@ -500,6 +520,13 @@ Re-export of deno_std's fs:
 for await (const file of $.fs.expandGlob("**/*.ts")) {
   console.log(file);
 }
+```
+
+Re-export of @sindresorhus's strip-ansi:
+
+```ts
+$.stripAnsi("\u001B[4mUnicorn\u001B[0m");
+//=> 'Unicorn'
 ```
 
 ## Making requests

--- a/README.md
+++ b/README.md
@@ -513,8 +513,8 @@ for await (const file of $.fs.expandGlob("**/*.ts")) {
 Remove ansi escape sequences from a string:
 
 ```ts
-$.stripAnsi("\u001B[4mUnicorn\u001B[0m");
-//=> 'Unicorn'
+$.stripAnsi("\u001B[4mHello World\u001B[0m");
+//=> 'Hello World'
 ```
 
 ## Making requests

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ for await (const file of $.fs.expandGlob("**/*.ts")) {
 }
 ```
 
-Re-export of @sindresorhus's strip-ansi:
+Remove ansi escape sequences from a string:
 
 ```ts
 $.stripAnsi("\u001B[4mUnicorn\u001B[0m");

--- a/README.md
+++ b/README.md
@@ -427,6 +427,14 @@ await $.exists("./file.txt");
 $.existsSync("./file.txt");
 ```
 
+Checking if a path does not exist:
+
+```ts
+// Note: beware of "time of check to time of use" race conditions when using this
+await $.missing("./file.txt");
+$.missingSync("./file.txt");
+```
+
 Sleeping asynchronously for a specified amount of time:
 
 ```ts
@@ -439,6 +447,32 @@ Getting path to an executable based on a command name:
 
 ```ts
 console.log(await $.which("deno")); // outputs the path to deno executable
+```
+
+Check if a command exists:
+
+```ts
+console.log(await $.commandExists("deno"));
+console.log($.commandExistsSync("deno"));
+```
+
+Check if a command does not exist:
+
+```ts
+console.log(await $.commandMissing("deno"));
+console.log($.commandMissingSync("deno"));
+```
+
+Check if an environment variable is set (and is not blank):
+
+```ts
+console.log($.envExists("HOME"));
+```
+
+Check if an environment variable is not set (or is blank):
+
+```ts
+console.log($.envMissing("HOME"));
 ```
 
 Attempting to do an action until it succeeds or hits the maximum number of retries:

--- a/README.md
+++ b/README.md
@@ -463,18 +463,6 @@ console.log(await $.commandMissing("deno"));
 console.log($.commandMissingSync("deno"));
 ```
 
-Check if an environment variable is set (and is not blank):
-
-```ts
-console.log($.envExists("HOME"));
-```
-
-Check if an environment variable is not set (or is blank):
-
-```ts
-console.log($.envMissing("HOME"));
-```
-
 Attempting to do an action until it succeeds or hits the maximum number of retries:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -479,13 +479,13 @@ await $.withRetries({
 "Dedent" or remove leading whitespace from a string:
 
 ```ts
-console.log($.dedent(`
+console.log($.dedent`
     This line will appear without any indentation.
       * This list will appear with 2 spaces more than previous line.
       * As will this line.
 
     Empty lines (like the one above) will not affect the common indentation.
-  `));
+  `);
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -427,14 +427,6 @@ await $.exists("./file.txt");
 $.existsSync("./file.txt");
 ```
 
-Checking if a path does not exist:
-
-```ts
-// Note: beware of "time of check to time of use" race conditions when using this
-await $.missing("./file.txt");
-$.missingSync("./file.txt");
-```
-
 Sleeping asynchronously for a specified amount of time:
 
 ```ts
@@ -454,13 +446,6 @@ Check if a command exists:
 ```ts
 console.log(await $.commandExists("deno"));
 console.log($.commandExistsSync("deno"));
-```
-
-Check if a command does not exist:
-
-```ts
-console.log(await $.commandMissing("deno"));
-console.log($.commandMissingSync("deno"));
 ```
 
 Attempting to do an action until it succeeds or hits the maximum number of retries:

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -978,3 +978,43 @@ async function isDir(path: string) {
   const info = await lstat(path);
   return info?.isDirectory ? true : false;
 }
+
+Deno.test("$.missing", async () => {
+  assertEquals(await $.missing("some-fake-file.json"), true);
+  assertEquals(await $.missing($.path.fromFileUrl(import.meta.url)), false);
+});
+
+Deno.test("$.missingSync", async () => {
+  assertEquals($.missingSync("some-fake-file.json"), true);
+  assertEquals($.missingSync($.path.fromFileUrl(import.meta.url)), false);
+});
+
+Deno.test("$.commandExists", async () => {
+  assertEquals(await $.commandExists("some-fake-command"), false);
+  assertEquals(await $.commandExists("deno"), true);
+});
+
+Deno.test("$.commandExistsSync", async () => {
+  assertEquals($.commandExistsSync("some-fake-command"), false);
+  assertEquals($.commandExistsSync("deno"), true);
+});
+
+Deno.test("$.commandMissing", async () => {
+  assertEquals(await $.commandMissing("some-fake-command"), true);
+  assertEquals(await $.commandMissing("deno"), false);
+});
+
+Deno.test("$.commandMissingSync", async () => {
+  assertEquals($.commandMissingSync("some-fake-command"), true);
+  assertEquals($.commandMissingSync("deno"), false);
+});
+
+Deno.test("$.envExists", async () => {
+  assertEquals($.envExists("PATH"), true);
+  assertEquals($.envExists("SOME_FAKE_ENV"), false);
+});
+
+Deno.test("$.envMissing", async () => {
+  assertEquals($.envMissing("PATH"), false);
+  assertEquals($.envMissing("SOME_FAKE_ENV"), true);
+});

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1009,16 +1009,6 @@ Deno.test("$.commandMissingSync", async () => {
   assertEquals($.commandMissingSync("deno"), false);
 });
 
-Deno.test("$.envExists", async () => {
-  assertEquals($.envExists("PATH"), true);
-  assertEquals($.envExists("SOME_FAKE_ENV"), false);
-});
-
-Deno.test("$.envMissing", async () => {
-  assertEquals($.envMissing("PATH"), false);
-  assertEquals($.envMissing("SOME_FAKE_ENV"), true);
-});
-
 Deno.test("$.stripAnsi", async () => {
   assertEquals($.stripAnsi("\u001B[4mUnicorn\u001B[0m"), "Unicorn");
   assertEquals($.stripAnsi("no ansi escapes here"), "no ansi escapes here");

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -979,16 +979,6 @@ async function isDir(path: string) {
   return info?.isDirectory ? true : false;
 }
 
-Deno.test("$.missing", async () => {
-  assertEquals(await $.missing("some-fake-file.json"), true);
-  assertEquals(await $.missing($.path.fromFileUrl(import.meta.url)), false);
-});
-
-Deno.test("$.missingSync", () => {
-  assertEquals($.missingSync("some-fake-file.json"), true);
-  assertEquals($.missingSync($.path.fromFileUrl(import.meta.url)), false);
-});
-
 Deno.test("$.commandExists", async () => {
   assertEquals(await $.commandExists("some-fake-command"), false);
   assertEquals(await $.commandExists("deno"), true);
@@ -997,16 +987,6 @@ Deno.test("$.commandExists", async () => {
 Deno.test("$.commandExistsSync", () => {
   assertEquals($.commandExistsSync("some-fake-command"), false);
   assertEquals($.commandExistsSync("deno"), true);
-});
-
-Deno.test("$.commandMissing", async () => {
-  assertEquals(await $.commandMissing("some-fake-command"), true);
-  assertEquals(await $.commandMissing("deno"), false);
-});
-
-Deno.test("$.commandMissingSync", () => {
-  assertEquals($.commandMissingSync("some-fake-command"), true);
-  assertEquals($.commandMissingSync("deno"), false);
 });
 
 Deno.test("$.stripAnsi", () => {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -984,7 +984,7 @@ Deno.test("$.missing", async () => {
   assertEquals(await $.missing($.path.fromFileUrl(import.meta.url)), false);
 });
 
-Deno.test("$.missingSync", async () => {
+Deno.test("$.missingSync", () => {
   assertEquals($.missingSync("some-fake-file.json"), true);
   assertEquals($.missingSync($.path.fromFileUrl(import.meta.url)), false);
 });
@@ -994,7 +994,7 @@ Deno.test("$.commandExists", async () => {
   assertEquals(await $.commandExists("deno"), true);
 });
 
-Deno.test("$.commandExistsSync", async () => {
+Deno.test("$.commandExistsSync", () => {
   assertEquals($.commandExistsSync("some-fake-command"), false);
   assertEquals($.commandExistsSync("deno"), true);
 });
@@ -1004,17 +1004,17 @@ Deno.test("$.commandMissing", async () => {
   assertEquals(await $.commandMissing("deno"), false);
 });
 
-Deno.test("$.commandMissingSync", async () => {
+Deno.test("$.commandMissingSync", () => {
   assertEquals($.commandMissingSync("some-fake-command"), true);
   assertEquals($.commandMissingSync("deno"), false);
 });
 
-Deno.test("$.stripAnsi", async () => {
+Deno.test("$.stripAnsi", () => {
   assertEquals($.stripAnsi("\u001B[4mHello World\u001B[0m"), "Hello World");
   assertEquals($.stripAnsi("no ansi escapes here"), "no ansi escapes here");
 });
 
-Deno.test("$.dedent", async () => {
+Deno.test("$.dedent", () => {
   const actual = $.dedent`
         This line will appear without any indentation.
           * This list will appear with 2 spaces more than previous line.

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1018,3 +1018,27 @@ Deno.test("$.envMissing", async () => {
   assertEquals($.envMissing("PATH"), false);
   assertEquals($.envMissing("SOME_FAKE_ENV"), true);
 });
+
+Deno.test("$.stripAnsi", async () => {
+  assertEquals($.stripAnsi("\u001B[4mUnicorn\u001B[0m"), "Unicorn");
+  assertEquals($.stripAnsi("no ansi escapes here"), "no ansi escapes here");
+});
+
+Deno.test("$.dedent", async () => {
+  const actual = $.dedent(`
+        This line will appear without any indentation.
+          * This list will appear with 2 spaces more than previous line.
+          * As will this line.
+
+        Empty lines (like the one above) will not affect the common indentation.
+  `);
+
+  const expected = `
+This line will appear without any indentation.
+  * This list will appear with 2 spaces more than previous line.
+  * As will this line.
+
+Empty lines (like the one above) will not affect the common indentation.`.trim();
+
+  assertEquals(actual, expected);
+});

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1010,7 +1010,7 @@ Deno.test("$.commandMissingSync", async () => {
 });
 
 Deno.test("$.stripAnsi", async () => {
-  assertEquals($.stripAnsi("\u001B[4mUnicorn\u001B[0m"), "Unicorn");
+  assertEquals($.stripAnsi("\u001B[4mHello World\u001B[0m"), "Hello World");
   assertEquals($.stripAnsi("no ansi escapes here"), "no ansi escapes here");
 });
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1015,13 +1015,13 @@ Deno.test("$.stripAnsi", async () => {
 });
 
 Deno.test("$.dedent", async () => {
-  const actual = $.dedent(`
+  const actual = $.dedent`
         This line will appear without any indentation.
           * This list will appear with 2 spaces more than previous line.
           * As will this line.
 
         Empty lines (like the one above) will not affect the common indentation.
-  `);
+  `;
 
   const expected = `
 This line will appear without any indentation.

--- a/mod.ts
+++ b/mod.ts
@@ -25,7 +25,8 @@ import {
   select,
   SelectOptions,
 } from "./src/console/mod.ts";
-import { colors, dedent, fs, path, stripAnsi, which, whichSync } from "./src/deps.ts";
+import { colors, dedent, fs, path, which, whichSync } from "./src/deps.ts";
+import { wasmInstance } from "./src/lib/mod.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 
 export { CommandBuilder, CommandResult } from "./src/command.ts";
@@ -158,13 +159,7 @@ export interface $Type {
    * ```
    */
   escapeArg(arg: string): string;
-  /**
-   * Strip ANSI escape codes from a string
-   *
-   * Re-export of https://www.npmjs.com/package/strip-ansi
-   *
-   * @see https://github.com/chalk/strip-ansi
-   */
+  /** Strip ANSI escape codes from a string */
   stripAnsi(text: string): string;
   /**
    * De-indents (dedents) passed in strings
@@ -562,7 +557,9 @@ const helperObject = {
   path,
   cd,
   escapeArg,
-  stripAnsi,
+  stripAnsi(text: string) {
+    return wasmInstance.strip_ansi_codes(text);
+  },
   dedent,
   async exists(path: string) {
     return fs.exists(path);

--- a/mod.ts
+++ b/mod.ts
@@ -159,6 +159,36 @@ export interface $Type {
    */
   escapeArg(arg: string): string;
   /**
+   * Strip ANSI escape codes from a string
+   *
+   * Re-export of https://www.npmjs.com/package/strip-ansi
+   *
+   * @see https://github.com/chalk/strip-ansi
+   */
+  stripAnsi(text: string): string;
+  /**
+   * De-indents (dedents) passed in strings
+   *
+   * Re-export of https://www.npmjs.com/package/string-dedent
+   *
+   * Removes the leading whitespace from each line,
+   * allowing you to break the string into multiple
+   * lines with indentation. If lines have an uneven
+   * amount of indentation, then only the common
+   * whitespace is removed.
+   *
+   * The opening and closing lines (which contain
+   * the ` marks) must be on their own line. The
+   * opening line must be empty, and the closing
+   * line may contain whitespace. The opening and
+   * closing line will be removed from the output,
+   * so that only the content in between remains.
+   *
+   * @see https://github.com/jridgewell/string-dedent
+   * @see https://github.com/tc39/proposal-string-dedent
+   */
+  dedent(text: string): string;
+  /**
    * Gets if the provided path exists asynchronously.
    *
    * Although there is a potential for a race condition between the
@@ -169,6 +199,101 @@ export interface $Type {
   exists(path: string): Promise<boolean>;
   /** Gets if the provided path exists synchronously. */
   existsSync(path: string): boolean;
+  /**
+   * Gets if the provided path does not exist asynchronously.
+   *
+   * Although there is a potential for a race condition between the
+   * time this check is made and the time some code is used, it may
+   * not be a big deal to use this in some scenarios and simplify
+   * the code a lot.
+   */
+  missing(path: string): Promise<boolean>;
+  /** Gets if the provided path does not exist synchronously. */
+  missingSync(path: string): boolean;
+  /**
+   * Using `$.which`, determine if the provided command exists
+   * resolving to `true` if `$.which` finds the specified
+   * command and to `false` otherwise.
+   *
+   * The following are equivalent:
+   *
+   * ```ts
+   * // use $.which directly
+   * if(typeof (await $.which('deno')) !== 'undefined') {
+   *   console.log('deno found');
+   * }
+   *
+   * // use $.commandExists
+   * if(await $.commandExists('deno')) {
+   *   console.log('deno found')
+   * }
+   * ```
+   */
+  commandExists(commandName: string): Promise<boolean>;
+  /** Gets if the provided command exists synchronously */
+  commandExistsSync(commandName: string): boolean;
+  /**
+   * Using `$.which`, determine if the provided command does
+   * not exist, resolving to `true` if `$.which` does not find
+   * the specified command and to `false` otherwise.
+   *
+   * The following are equivalent:
+   *
+   * ```ts
+   * // use $.which directly
+   * if(typeof (await $.which('deno')) === 'undefined') {
+   *   console.log('deno was not found');
+   * }
+   *
+   * // use $.commandMissing
+   * if(await $.commandMissing('deno')) {
+   *   console.log('deno was not found')
+   * }
+   * ```
+   */
+  commandMissing(commandName: string): Promise<boolean>;
+  /** Gets if the provided command does not exist synchronously */
+  commandMissingSync(commandName: string): boolean;
+  /**
+   * Check if the provided environment variable is defined and
+   * has a non-blank value.
+   *
+   * The following are equivalent:
+   *
+   * ```ts
+   * // use Deno.env directly
+   * const maybeHome = Deno.env.get('HOME')
+   * if(typeof maybeHome === 'string' && maybeHome.trim().length > 0) {
+   *   console.log('$HOME is well defined')
+   * }
+   *
+   * // use $.envExists
+   * if($.envExists('HOME')) {
+   *   console.log('$HOME is well defined')
+   * }
+   * ```
+   */
+  envExists(envName: string): boolean;
+  /**
+   * Check if the provided environment variable is not defined or
+   * is defined but has a blank value.
+   *
+   * The following are equivalent:
+   *
+   * ```ts
+   * // use Deno.env directly
+   * const homeOrDefault = Deno.env.get('HOME') ?? ""
+   * if(homeOrDefault.trim().length === 0) {
+   *   console.log('$HOME is not well defined')
+   * }
+   *
+   * // use $.envMissing
+   * if($.envMissing('HOME')) {
+   *   console.log('$HOME is not well defined')
+   * }
+   * ```
+   */
+  envMissing(envName: string): boolean;
   /** Re-export of deno_std's `fs` module. */
   fs: typeof fs;
   /** Re-export of deno_std's `path` module. */
@@ -478,11 +603,7 @@ const helperObject = {
   cd,
   escapeArg,
   stripAnsi,
-  dedent(text: string) {
-    // not a re-export because use as a tagged template can be problematic if
-    // it is used inside of _another_ tagged template (i.e. in $.log, etc)
-    return dedent(text);
-  },
+  dedent,
   async exists(path: string) {
     return fs.exists(path);
   },

--- a/mod.ts
+++ b/mod.ts
@@ -25,7 +25,7 @@ import {
   select,
   SelectOptions,
 } from "./src/console/mod.ts";
-import { colors, dedent, fs, path, which, whichSync } from "./src/deps.ts";
+import { colors, fs, outdent, path, which, whichSync } from "./src/deps.ts";
 import { wasmInstance } from "./src/lib/mod.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 
@@ -162,9 +162,9 @@ export interface $Type {
   /** Strip ANSI escape codes from a string */
   stripAnsi(text: string): string;
   /**
-   * De-indents (dedents) passed in strings
+   * De-indent (a.k.a. dedent/outdent) template literal strings
    *
-   * Re-export of https://www.npmjs.com/package/string-dedent
+   * Re-export of https://deno.land/x/outdent
    *
    * Removes the leading whitespace from each line,
    * allowing you to break the string into multiple
@@ -178,11 +178,8 @@ export interface $Type {
    * line may contain whitespace. The opening and
    * closing line will be removed from the output,
    * so that only the content in between remains.
-   *
-   * @see https://github.com/jridgewell/string-dedent
-   * @see https://github.com/tc39/proposal-string-dedent
    */
-  dedent(text: string): string;
+  dedent: typeof outdent;
   /**
    * Gets if the provided path exists asynchronously.
    *
@@ -560,7 +557,7 @@ const helperObject = {
   stripAnsi(text: string) {
     return wasmInstance.strip_ansi_codes(text);
   },
-  dedent,
+  dedent: outdent,
   async exists(path: string) {
     return fs.exists(path);
   },

--- a/mod.ts
+++ b/mod.ts
@@ -558,20 +558,20 @@ const helperObject = {
     return wasmInstance.strip_ansi_codes(text);
   },
   dedent: outdent,
-  async exists(path: string) {
+  exists(path: string) {
     return fs.exists(path);
   },
   existsSync(path: string) {
     return fs.existsSync(path);
   },
-  async missing(path: string) {
+  missing(path: string) {
     return fs.exists(path).then((exists) => !exists);
   },
   missingSync(path: string) {
     return !fs.existsSync(path);
   },
   sleep,
-  async which(commandName: string) {
+  which(commandName: string) {
     if (commandName.toUpperCase() === "DENO") {
       return Promise.resolve(Deno.execPath());
     } else {
@@ -585,13 +585,13 @@ const helperObject = {
       return whichSync(commandName);
     }
   },
-  async commandExists(commandName: string) {
+  commandExists(commandName: string) {
     return this.which(commandName).then((c) => typeof c !== "undefined");
   },
   commandExistsSync(commandName: string) {
     return typeof this.whichSync(commandName) !== "undefined";
   },
-  async commandMissing(commandName: string) {
+  commandMissing(commandName: string) {
     return this.which(commandName).then((c) => typeof c === "undefined");
   },
   commandMissingSync(commandName: string) {

--- a/mod.ts
+++ b/mod.ts
@@ -254,46 +254,6 @@ export interface $Type {
   commandMissing(commandName: string): Promise<boolean>;
   /** Gets if the provided command does not exist synchronously */
   commandMissingSync(commandName: string): boolean;
-  /**
-   * Check if the provided environment variable is defined and
-   * has a non-blank value.
-   *
-   * The following are equivalent:
-   *
-   * ```ts
-   * // use Deno.env directly
-   * const maybeHome = Deno.env.get('HOME')
-   * if(typeof maybeHome === 'string' && maybeHome.trim().length > 0) {
-   *   console.log('$HOME is well defined')
-   * }
-   *
-   * // use $.envExists
-   * if($.envExists('HOME')) {
-   *   console.log('$HOME is well defined')
-   * }
-   * ```
-   */
-  envExists(envName: string): boolean;
-  /**
-   * Check if the provided environment variable is not defined or
-   * is defined but has a blank value.
-   *
-   * The following are equivalent:
-   *
-   * ```ts
-   * // use Deno.env directly
-   * const homeOrDefault = Deno.env.get('HOME') ?? ""
-   * if(homeOrDefault.trim().length === 0) {
-   *   console.log('$HOME is not well defined')
-   * }
-   *
-   * // use $.envMissing
-   * if($.envMissing('HOME')) {
-   *   console.log('$HOME is not well defined')
-   * }
-   * ```
-   */
-  envMissing(envName: string): boolean;
   /** Re-export of deno_std's `fs` module. */
   fs: typeof fs;
   /** Re-export of deno_std's `path` module. */
@@ -642,14 +602,6 @@ const helperObject = {
   },
   commandMissingSync(commandName: string) {
     return typeof this.whichSync(commandName) === "undefined";
-  },
-  envExists(envName: string) {
-    const value = Deno.env.get(envName)?.trim() ?? "";
-    return value.length > 0;
-  },
-  envMissing(envName: string) {
-    const value = Deno.env.get(envName)?.trim() ?? "";
-    return value.length === 0;
   },
 };
 

--- a/mod.ts
+++ b/mod.ts
@@ -635,13 +635,13 @@ const helperObject = {
     return this.which(commandName).then((c) => typeof c !== "undefined");
   },
   commandExistsSync(commandName: string) {
-    return typeof this.whichSync(commandName) === "undefined";
+    return typeof this.whichSync(commandName) !== "undefined";
   },
   async commandMissing(commandName: string) {
     return this.which(commandName).then((c) => typeof c === "undefined");
   },
   commandMissingSync(commandName: string) {
-    return typeof this.whichSync(commandName) !== "undefined";
+    return typeof this.whichSync(commandName) === "undefined";
   },
   envExists(envName: string) {
     const value = Deno.env.get(envName)?.trim() ?? "";

--- a/mod.ts
+++ b/mod.ts
@@ -25,7 +25,7 @@ import {
   select,
   SelectOptions,
 } from "./src/console/mod.ts";
-import { colors, fs, path, which, whichSync } from "./src/deps.ts";
+import { colors, dedent, fs, path, stripAnsi, which, whichSync } from "./src/deps.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 
 export { CommandBuilder, CommandResult } from "./src/command.ts";
@@ -477,6 +477,12 @@ const helperObject = {
   path,
   cd,
   escapeArg,
+  stripAnsi,
+  dedent(text: string) {
+    // not a re-export because use as a tagged template can be problematic if
+    // it is used inside of _another_ tagged template (i.e. in $.log, etc)
+    return dedent(text);
+  },
   async exists(path: string) {
     return fs.exists(path);
   },

--- a/mod.ts
+++ b/mod.ts
@@ -192,17 +192,6 @@ export interface $Type {
   /** Gets if the provided path exists synchronously. */
   existsSync(path: string): boolean;
   /**
-   * Gets if the provided path does not exist asynchronously.
-   *
-   * Although there is a potential for a race condition between the
-   * time this check is made and the time some code is used, it may
-   * not be a big deal to use this in some scenarios and simplify
-   * the code a lot.
-   */
-  missing(path: string): Promise<boolean>;
-  /** Gets if the provided path does not exist synchronously. */
-  missingSync(path: string): boolean;
-  /**
    * Using `$.which`, determine if the provided command exists
    * resolving to `true` if `$.which` finds the specified
    * command and to `false` otherwise.
@@ -224,28 +213,6 @@ export interface $Type {
   commandExists(commandName: string): Promise<boolean>;
   /** Gets if the provided command exists synchronously */
   commandExistsSync(commandName: string): boolean;
-  /**
-   * Using `$.which`, determine if the provided command does
-   * not exist, resolving to `true` if `$.which` does not find
-   * the specified command and to `false` otherwise.
-   *
-   * The following are equivalent:
-   *
-   * ```ts
-   * // use $.which directly
-   * if(typeof (await $.which('deno')) === 'undefined') {
-   *   console.log('deno was not found');
-   * }
-   *
-   * // use $.commandMissing
-   * if(await $.commandMissing('deno')) {
-   *   console.log('deno was not found')
-   * }
-   * ```
-   */
-  commandMissing(commandName: string): Promise<boolean>;
-  /** Gets if the provided command does not exist synchronously */
-  commandMissingSync(commandName: string): boolean;
   /** Re-export of deno_std's `fs` module. */
   fs: typeof fs;
   /** Re-export of deno_std's `path` module. */
@@ -564,12 +531,6 @@ const helperObject = {
   existsSync(path: string) {
     return fs.existsSync(path);
   },
-  missing(path: string) {
-    return fs.exists(path).then((exists) => !exists);
-  },
-  missingSync(path: string) {
-    return !fs.existsSync(path);
-  },
   sleep,
   which(commandName: string) {
     if (commandName.toUpperCase() === "DENO") {
@@ -590,12 +551,6 @@ const helperObject = {
   },
   commandExistsSync(commandName: string) {
     return typeof this.whichSync(commandName) !== "undefined";
-  },
-  commandMissing(commandName: string) {
-    return this.which(commandName).then((c) => typeof c === "undefined");
-  },
-  commandMissingSync(commandName: string) {
-    return typeof this.whichSync(commandName) === "undefined";
   },
 };
 

--- a/mod.ts
+++ b/mod.ts
@@ -477,14 +477,20 @@ const helperObject = {
   path,
   cd,
   escapeArg,
+  async exists(path: string) {
+    return fs.exists(path);
+  },
   existsSync(path: string) {
     return fs.existsSync(path);
   },
-  exists(path: string) {
-    return fs.exists(path);
+  async missing(path: string) {
+    return fs.exists(path).then((exists) => !exists);
+  },
+  missingSync(path: string) {
+    return !fs.existsSync(path);
   },
   sleep,
-  which(commandName: string) {
+  async which(commandName: string) {
     if (commandName.toUpperCase() === "DENO") {
       return Promise.resolve(Deno.execPath());
     } else {
@@ -497,6 +503,26 @@ const helperObject = {
     } else {
       return whichSync(commandName);
     }
+  },
+  async commandExists(commandName: string) {
+    return this.which(commandName).then((c) => typeof c !== "undefined");
+  },
+  commandExistsSync(commandName: string) {
+    return typeof this.whichSync(commandName) === "undefined";
+  },
+  async commandMissing(commandName: string) {
+    return this.which(commandName).then((c) => typeof c === "undefined");
+  },
+  commandMissingSync(commandName: string) {
+    return typeof this.whichSync(commandName) !== "undefined";
+  },
+  envExists(envName: string) {
+    const value = Deno.env.get(envName)?.trim() ?? "";
+    return value.length > 0;
+  },
+  envMissing(envName: string) {
+    const value = Deno.env.get(envName)?.trim() ?? "";
+    return value.length === 0;
   },
 };
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -7,3 +7,6 @@ export { readAll } from "https://deno.land/std@0.170.0/streams/read_all.ts";
 export { writeAllSync } from "https://deno.land/std@0.170.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
 export { RealEnvironment as DenoWhichRealEnvironment, which, whichSync } from "https://deno.land/x/which@0.2.1/mod.ts";
+export { default as stripAnsi } from "npm:strip-ansi@7.0.1";
+import dedentImport from "npm:string-dedent@3.0.1";
+export const dedent = dedentImport as any as typeof dedentImport["default"];

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -6,5 +6,5 @@ export * as path from "https://deno.land/std@0.170.0/path/mod.ts";
 export { readAll } from "https://deno.land/std@0.170.0/streams/read_all.ts";
 export { writeAllSync } from "https://deno.land/std@0.170.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
-export { outdent } from "https://deno.land/x/outdent@v0.8.0/mod.ts";
+export { outdent } from "https://deno.land/x/outdent@v0.8.0/src/index.ts";
 export { RealEnvironment as DenoWhichRealEnvironment, which, whichSync } from "https://deno.land/x/which@0.2.1/mod.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -7,6 +7,5 @@ export { readAll } from "https://deno.land/std@0.170.0/streams/read_all.ts";
 export { writeAllSync } from "https://deno.land/std@0.170.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
 export { RealEnvironment as DenoWhichRealEnvironment, which, whichSync } from "https://deno.land/x/which@0.2.1/mod.ts";
-export { default as stripAnsi } from "npm:strip-ansi@7.0.1";
 import dedentImport from "npm:string-dedent@3.0.1";
 export const dedent = dedentImport as any as typeof dedentImport["default"];

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -6,6 +6,5 @@ export * as path from "https://deno.land/std@0.170.0/path/mod.ts";
 export { readAll } from "https://deno.land/std@0.170.0/streams/read_all.ts";
 export { writeAllSync } from "https://deno.land/std@0.170.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
+export { outdent } from "https://deno.land/x/outdent@v0.8.0/mod.ts";
 export { RealEnvironment as DenoWhichRealEnvironment, which, whichSync } from "https://deno.land/x/which@0.2.1/mod.ts";
-import dedentImport from "npm:string-dedent@3.0.1";
-export const dedent = dedentImport as any as typeof dedentImport["default"];


### PR DESCRIPTION
Thank you very much for `dax`! I really love using it and it has been rock solid as a basis for a rewrite I've just completed of my dotfiles repository (https://github.com/andrewbrey/dotfiles). As you can see if you poke around that repo, it's a lot more than _just_ dotfiles - it's more like a personal toolkit to take a computer from fresh OS install to set up exactly as I prefer.

In creating this repo, I found myself wishing that `dax` had  _just a few_ more helpers dangling off of `$` because of how ubiquitous the `$` import was in my modules and how commonly I encountered a few things like:

- Check if a path is missing (the inverse of `$.exists`)
- Check if a command is defined/undefined (based off of `$.which`)
- Check if an environment variable is well defined
- De-indent (dedent) template strings for printing formatted log messages 

This PR adds some of the most useful of these to the `$` "helpers". I think that each of these is very common in many kinds of scripts that deal with shell input/output, and having them readily available with a bit less boilerplate required would be quite helpful!

Cheers!

**EDIT:** note that the implementation of `dedent` chosen is the one referenced by the [stage 2 TC39 proposal-string-dedent](https://github.com/tc39/proposal-string-dedent) within the "playground" link, in specific, this one https://github.com/jridgewell/string-dedent . The `string-dedent` module is maintained by one of the two champions of the referenced TC39 proposal :+1: 