### PR TITLE
refactor: use a top level await for the wasm instance to improve the api

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,11 +401,11 @@ The progress bars are updated on an interval (via `setInterval`). If you are doi
 ```ts
 const pb = $.progress("Processing Items");
 
-await pb.with(async () => {
+pb.with(() => {
   for (const item of items) {
     doWork(item);
     pb.increment();
-    await pb.forceRender();
+    pb.forceRender();
   }
 });
 ```

--- a/src/command.ts
+++ b/src/command.ts
@@ -419,7 +419,7 @@ export async function parseAndSpawnCommand(state: CommandBuilderState) {
   }
 
   try {
-    const list = await parseCommand(state.command);
+    const list = parseCommand(state.command);
     const code = await spawn(list, {
       stdin: state.stdin,
       stdout,

--- a/src/console/confirm.test.ts
+++ b/src/console/confirm.test.ts
@@ -3,8 +3,8 @@ import { assertEquals } from "../deps.test.ts";
 import { createTester } from "./testUtils.ts";
 import { Keys } from "./utils.ts";
 
-Deno.test("should render when default is false", async () => {
-  const tester = await createTester(innerConfirm({
+Deno.test("should render when default is false", () => {
+  const tester = createTester(innerConfirm({
     message: "Some question?",
     default: false,
   }));
@@ -24,8 +24,8 @@ Deno.test("should render when default is false", async () => {
   assertEquals(tester.getText(), "Some question? N");
 });
 
-Deno.test("should render when default is true", async () => {
-  const tester = await createTester(innerConfirm({
+Deno.test("should render when default is true", () => {
+  const tester = createTester(innerConfirm({
     message: "Some question?",
     default: true,
   }));
@@ -39,8 +39,8 @@ Deno.test("should render when default is true", async () => {
   assertEquals(tester.getText(), "Some question? Y");
 });
 
-Deno.test("should render when default is undefined", async () => {
-  const tester = await createTester(innerConfirm({
+Deno.test("should render when default is undefined", () => {
+  const tester = createTester(innerConfirm({
     message: "Some question?",
   }));
 

--- a/src/console/multiSelect.test.ts
+++ b/src/console/multiSelect.test.ts
@@ -3,8 +3,8 @@ import { assertEquals } from "../deps.test.ts";
 import { createTester } from "./testUtils.ts";
 import { Keys } from "./utils.ts";
 
-Deno.test("should render", async () => {
-  const tester = await createTester(innerMultiSelect({
+Deno.test("should render", () => {
+  const tester = createTester(innerMultiSelect({
     message: "Some question?",
     options: [
       "Option 1",
@@ -83,8 +83,8 @@ Deno.test("should render", async () => {
   );
 });
 
-Deno.test("should render when nothing selected", async () => {
-  const tester = await createTester(innerMultiSelect({
+Deno.test("should render when nothing selected", () => {
+  const tester = createTester(innerMultiSelect({
     message: "Some question?",
     options: ["Option 1", "Option 2", "Option 3"],
   }));

--- a/src/console/progress/interval.ts
+++ b/src/console/progress/interval.ts
@@ -15,9 +15,7 @@ export function addProgressBar(render: (size: ConsoleSize) => TextItem[]): Rende
   };
   progressBars.push(pb);
   if (renderIntervalId == null && isOutputTty) {
-    const _ignore = logger.ensureInitialized()
-      .catch(() => {/* ignore */});
-    renderIntervalId = setInterval(forceRenderSync, intervalMs);
+    renderIntervalId = setInterval(forceRender, intervalMs);
   }
   return pb;
 }
@@ -37,21 +35,6 @@ export function removeProgressBar(pb: RenderIntervalProgressBar) {
 }
 
 export function forceRender() {
-  if (!isShowingProgressBars()) {
-    return;
-  }
-
-  if (logger.isInitilaized()) {
-    forceRenderSync();
-    return Promise.resolve();
-  } else {
-    return logger.ensureInitialized().then(() => {
-      forceRenderSync();
-    });
-  }
-}
-
-function forceRenderSync() {
   if (!isShowingProgressBars()) {
     return;
   }

--- a/src/console/progress/mod.test.ts
+++ b/src/console/progress/mod.test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from "../../deps.test.ts";
-import { instantiateWithCaching } from "../../lib/mod.ts";
+import { wasmInstance } from "../../lib/mod.ts";
 import { renderProgressBar } from "./mod.ts";
 
-const { strip_ansi_codes, static_text_render_once } = await instantiateWithCaching();
+const { strip_ansi_codes, static_text_render_once } = wasmInstance;
 
 Deno.test("should render when no length", () => {
   assertEquals(

--- a/src/console/prompt.test.ts
+++ b/src/console/prompt.test.ts
@@ -3,8 +3,8 @@ import { assertEquals } from "../deps.test.ts";
 import { createTester } from "./testUtils.ts";
 import { Keys } from "./utils.ts";
 
-Deno.test("should render", async () => {
-  const tester = await createTester(innerPrompt({
+Deno.test("should render", () => {
+  const tester = createTester(innerPrompt({
     message: "Some question?",
   }));
 
@@ -23,8 +23,8 @@ Deno.test("should render", async () => {
   assertEquals(tester.getText(), "Some question? Ac d");
 });
 
-Deno.test("should render with default", async () => {
-  const tester = await createTester(innerPrompt({
+Deno.test("should render with default", () => {
+  const tester = createTester(innerPrompt({
     message: "Some question?",
     default: "test",
   }));

--- a/src/console/select.test.ts
+++ b/src/console/select.test.ts
@@ -3,8 +3,8 @@ import { assertEquals } from "../deps.test.ts";
 import { createTester } from "./testUtils.ts";
 import { Keys } from "./utils.ts";
 
-Deno.test("should render", async () => {
-  const tester = await createTester(innerSelect({
+Deno.test("should render", () => {
+  const tester = createTester(innerSelect({
     message: "Some question?",
     options: [
       "Option 1",

--- a/src/console/testUtils.ts
+++ b/src/console/testUtils.ts
@@ -1,10 +1,10 @@
-import { instantiateWithCaching } from "../lib/mod.ts";
+import { wasmInstance } from "../lib/mod.ts";
 import { Keys, SelectionOptions } from "./utils.ts";
 
-export async function createTester<TReturn>(
+export function createTester<TReturn>(
   renderer: Pick<SelectionOptions<TReturn | undefined>, "render" | "onKey">,
 ) {
-  const { static_text_render_once, strip_ansi_codes } = await instantiateWithCaching();
+  const { static_text_render_once, strip_ansi_codes } = wasmInstance;
   return {
     onKey(key: string | Keys) {
       return renderer.onKey(key);

--- a/src/lib/mod.ts
+++ b/src/lib/mod.ts
@@ -3,21 +3,12 @@ import { instantiate } from "./rs_lib.generated.js";
 
 export type WasmInstance = Awaited<ReturnType<typeof instantiate>>;
 
-let cachedInstance: WasmInstance | undefined;
-
-export async function instantiateWithCaching() {
-  if (cachedInstance == null) {
-    let url = new URL("rs_lib_bg.wasm", import.meta.url);
-    if (url.protocol !== "file:") {
-      url = (await cacheLocalDir(url)) ?? url;
-    }
-    cachedInstance = await instantiate({ url });
+async function getWasmFileUrl() {
+  const url = new URL("rs_lib_bg.wasm", import.meta.url);
+  if (url.protocol !== "file:") {
+    return (await cacheLocalDir(url)) ?? url;
   }
-  return cachedInstance;
-}
-
-export function getIfInstantiated() {
-  return cachedInstance;
+  return url;
 }
 
 async function cacheLocalDir(url: URL) {
@@ -67,3 +58,7 @@ async function getUrlBytes(url: URL) {
   }
   return await response.arrayBuffer();
 }
+
+export const wasmInstance = await instantiate({
+  url: await getWasmFileUrl(),
+});

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,7 +1,7 @@
 import { CommandContext, CommandHandler } from "./command_handler.ts";
 import { getExecutableShebangFromPath, ShebangInfo } from "./common.ts";
 import { DenoWhichRealEnvironment, path, which } from "./deps.ts";
-import { instantiateWithCaching } from "./lib/mod.ts";
+import { wasmInstance } from "./lib/mod.ts";
 import { ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind } from "./pipes.ts";
 import { EnvChange, ExecuteResult, resultFromCode } from "./result.ts";
 
@@ -337,9 +337,8 @@ export class Context {
   }
 }
 
-export async function parseCommand(command: string) {
-  const { parse } = await instantiateWithCaching();
-  return parse(command) as SequentialList;
+export function parseCommand(command: string) {
+  return wasmInstance.parse(command) as SequentialList;
 }
 
 export interface SpawnOpts {
@@ -743,7 +742,7 @@ async function parseShebangArgs(info: ShebangInfo, context: Context): Promise<st
   }
 
   // todo: move shebang parsing into deno_task_shell and investigate actual shebang parsing behaviour
-  const command = await parseCommand(info.command);
+  const command = parseCommand(info.command);
   if (command.items.length !== 1) {
     throwUnsupported();
   }


### PR DESCRIPTION
Too much of a hassle to not do this.