### PR TITLE
feat: `$.commandExists` should take into account registered commands on the `$`

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -982,11 +982,25 @@ async function isDir(path: string) {
 Deno.test("$.commandExists", async () => {
   assertEquals(await $.commandExists("some-fake-command"), false);
   assertEquals(await $.commandExists("deno"), true);
+
+  const $new = build$({
+    commandBuilder: new CommandBuilder().registerCommand("some-fake-command", () => {
+      return Promise.resolve({ code: 0, kind: "continue" });
+    }),
+  });
+  assertEquals(await $new.commandExists("some-fake-command"), true);
 });
 
 Deno.test("$.commandExistsSync", () => {
   assertEquals($.commandExistsSync("some-fake-command"), false);
   assertEquals($.commandExistsSync("deno"), true);
+
+  const $new = build$({
+    commandBuilder: new CommandBuilder().registerCommand("some-fake-command", () => {
+      return Promise.resolve({ code: 0, kind: "continue" });
+    }),
+  });
+  assertEquals($new.commandExistsSync("some-fake-command"), true);
 });
 
 Deno.test("$.stripAnsi", () => {

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { CommandBuilder, CommandResult, escapeArg } from "./src/command.ts";
+import { CommandBuilder, CommandResult, escapeArg, getRegisteredCommandNamesSymbol } from "./src/command.ts";
 import {
   Box,
   Delay,
@@ -638,13 +638,13 @@ function build$FromState(state: $State) {
         }
       },
       commandExists(commandName: string) {
-        if (state.commandBuilder.getValue().getRegisteredCommandNames().includes(commandName)) {
+        if (state.commandBuilder.getValue()[getRegisteredCommandNamesSymbol]().includes(commandName)) {
           return Promise.resolve(true);
         }
         return helperObject.which(commandName).then((c) => c != null);
       },
       commandExistsSync(commandName: string) {
-        if (state.commandBuilder.getValue().getRegisteredCommandNames().includes(commandName)) {
+        if (state.commandBuilder.getValue()[getRegisteredCommandNamesSymbol]().includes(commandName)) {
           return true;
         }
         return helperObject.whichSync(commandName) != null;

--- a/mod.ts
+++ b/mod.ts
@@ -160,10 +160,10 @@ export interface $Type {
    * ```
    */
   escapeArg(arg: string): string;
-  /** Strip ANSI escape codes from a string */
+  /** Strips ANSI escape codes from a string */
   stripAnsi(text: string): string;
   /**
-   * De-indent (a.k.a. dedent/outdent) template literal strings
+   * De-indents (a.k.a. dedent/outdent) template literal strings
    *
    * Re-export of https://deno.land/x/outdent
    *
@@ -193,26 +193,14 @@ export interface $Type {
   /** Gets if the provided path exists synchronously. */
   existsSync(path: string): boolean;
   /**
-   * Using `$.which`, determine if the provided command exists
-   * resolving to `true` if `$.which` finds the specified
-   * command and to `false` otherwise.
-   *
-   * The following are equivalent:
-   *
-   * ```ts
-   * // use $.which directly
-   * if(typeof (await $.which('deno')) !== 'undefined') {
-   *   console.log('deno found');
-   * }
-   *
-   * // use $.commandExists
-   * if(await $.commandExists('deno')) {
-   *   console.log('deno found')
-   * }
-   * ```
+   * Determines if the provided command exists resolving to `true` if the command
+   * will be resolved by the shell of the current `$` or false otherwise.
    */
   commandExists(commandName: string): Promise<boolean>;
-  /** Gets if the provided command exists synchronously */
+  /**
+   * Determines if the provided command exists resolving to `true` if the command
+   * will be resolved by the shell of the current `$` or false otherwise.
+   */
   commandExistsSync(commandName: string): boolean;
   /** Re-export of deno_std's `fs` module. */
   fs: typeof fs;
@@ -549,12 +537,6 @@ const helperObject = {
       return whichSync(commandName);
     }
   },
-  commandExists(commandName: string) {
-    return this.which(commandName).then((c) => typeof c !== "undefined");
-  },
-  commandExistsSync(commandName: string) {
-    return typeof this.whichSync(commandName) !== "undefined";
-  },
 };
 
 /** Options for creating a custom `$`. */
@@ -654,6 +636,18 @@ function build$FromState(state: $State) {
         if (state.indentLevel.value > 0) {
           state.indentLevel.value--;
         }
+      },
+      commandExists(commandName: string) {
+        if (state.commandBuilder.getValue().getRegisteredCommandNames().includes(commandName)) {
+          return Promise.resolve(true);
+        }
+        return helperObject.which(commandName).then((c) => c != null);
+      },
+      commandExistsSync(commandName: string) {
+        if (state.commandBuilder.getValue().getRegisteredCommandNames().includes(commandName)) {
+          return true;
+        }
+        return helperObject.whichSync(commandName) != null;
       },
       maybeConfirm,
       confirm,

--- a/src/command.ts
+++ b/src/command.ts
@@ -56,6 +56,7 @@ const builtInCommands = {
   pwd: pwdCommand,
 };
 
+/** @internal */
 export const getRegisteredCommandNamesSymbol = Symbol();
 
 /**

--- a/src/command.ts
+++ b/src/command.ts
@@ -391,6 +391,14 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
   async json<TResult = any>(): Promise<TResult> {
     return (await this.quiet("stdout")).stdoutJson;
   }
+
+  /**
+   * @internal
+   * Gets the registered command names.
+   */
+  getRegisteredCommandNames() {
+    return Object.keys(this.#state.commands);
+  }
 }
 
 export async function parseAndSpawnCommand(state: CommandBuilderState) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -56,6 +56,8 @@ const builtInCommands = {
   pwd: pwdCommand,
 };
 
+export const getRegisteredCommandNamesSymbol = Symbol();
+
 /**
  * Underlying builder API for executing commands.
  *
@@ -392,11 +394,8 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
     return (await this.quiet("stdout")).stdoutJson;
   }
 
-  /**
-   * @internal
-   * Gets the registered command names.
-   */
-  getRegisteredCommandNames() {
+  /** @internal */
+  [getRegisteredCommandNamesSymbol]() {
     return Object.keys(this.#state.commands);
   }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -20,6 +20,7 @@ interface RequestBuilderState {
   timeout: number | undefined;
 }
 
+/** @internal */
 export const withProgressBarFactorySymbol = Symbol();
 
 /**


### PR DESCRIPTION
Just thought of this afterwards.