### PR TITLE
fix: `exit` command should work in boolean list if not first item

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -121,6 +121,23 @@ Deno.test("should throw when exit code is non-zero", async () => {
     Error,
     "Exited with code: 2",
   );
+
+  await assertRejects(
+    async () => {
+      await $`exit 3 && echo 1 && echo 2`;
+    },
+    Error,
+    "Exited with code: 3",
+  );
+
+  // regression test for previous bug
+  await assertRejects(
+    async () => {
+      await $`echo 1 && echo 2 && exit 3`;
+    },
+    Error,
+    "Exited with code: 3",
+  );
 });
 
 Deno.test("should change the cwd, but only in the shell", async () => {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -461,7 +461,7 @@ async function executeBooleanList(list: BooleanList, context: Context): Promise<
     );
     switch (nextResult.kind) {
       case "exit":
-        return firstResult;
+        return nextResult;
       case "continue":
         if (nextResult.changes) {
           changes.push(...nextResult.changes);


### PR DESCRIPTION
Bug.