### PR TITLE
feat: add streaming api for command inputs and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ console.log(finalText); // 1
 ### Providing stdin
 
 ```ts
-await $`command`.stdin("some value");
+await $`command`.stdin("inherit"); // default
+await $`command`.stdin("null");
 await $`command`.stdin(new Uint8Array[1, 2, 3, 4]());
 await $`command`.stdin(someReaderOrReadableStream);
+await $`command`.stdinText("some value");
 ```
 
 ## Streaming API
@@ -216,9 +218,25 @@ await $`echo ${text}`; // will output `> echo example` before running the comman
 
 ### Timeout a command
 
+This will exit with code 124.
+
 ```ts
 // timeout a command after a specified time
-await $`some_command`.timeout("1s");
+await $`echo 1 && sleep 100 && echo 2`.timeout("1s");
+```
+
+### Aborting a command
+
+Instead of awaiting the template literal, you can get a command child by calling the `.spawn()` method:
+
+```ts
+const child = $`echo 1 && sleep 100 && echo 2`.spawn();
+
+// abort the child after 1s
+await $.sleep("1s");
+child.abort();
+
+await child; // Error: Aborted with exit code: 124
 ```
 
 ### Exporting the environment of the shell to JavaScript

--- a/README.md
+++ b/README.md
@@ -135,7 +135,19 @@ console.log(finalText); // 1
 ```ts
 await $`command`.stdin("some value");
 await $`command`.stdin(new Uint8Array[1, 2, 3, 4]());
-await $`command`.stdin(someReader);
+await $`command`.stdin(someReaderOrReadableStream);
+```
+
+## Streaming API
+
+Awaiting a command will get the `CommandResult`, but calling `.spawn()` on a command without `await` will return a `CommandChild`. This has some methods on it to get readable streams of stdout and stderr of the executing command if the corresponding pipe is set to `"piped"`. These can then be piped wherever you'd like such as another command's stdin:
+
+```ts
+const child = $`echo 1 && sleep 1 && echo 2`
+  .stdout("piped")
+  .spawn();
+await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+  .stdin(child.stdout());
 ```
 
 ### Setting environment variables

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,7 +1,8 @@
+import { readAll } from "./src/deps.ts";
 import $, { build$, CommandBuilder, CommandContext, CommandHandler } from "./mod.ts";
 import { lstat, rustJoin } from "./src/common.ts";
 import { assert, assertEquals, assertRejects, assertStringIncludes, assertThrows } from "./src/deps.test.ts";
-import { Buffer, colors, path } from "./src/deps.ts";
+import { Buffer, colors, path, readerFromStreamReader } from "./src/deps.ts";
 
 Deno.test("should get stdout when piped", async () => {
   const output = await $`echo 5`.stdout("piped");
@@ -639,6 +640,150 @@ Deno.test("piping to stdin", async () => {
         .stdin(new TextEncoder().encode("test\n"))
         .text();
     assertEquals(result, "test");
+  }
+
+  // readable stream
+  {
+    const child = $`echo 1 && echo 2`.stdout("piped").spawn();
+    const result = await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+      .stdin(child.stdout())
+      .text();
+    assertEquals(result, "1\n2");
+  }
+});
+
+Deno.test("streaming api not piped", async () => {
+  const child = $`echo 1 && echo 2`.spawn();
+  assertThrows(
+    () => child.stdout(),
+    Error,
+    `No pipe available. Ensure stdout is "piped" (not "inheritPiped") and combinedOutput is not enabled.`,
+  );
+  assertThrows(
+    () => child.stderr(),
+    Error,
+    `No pipe available. Ensure stderr is "piped" (not "inheritPiped") and combinedOutput is not enabled.`,
+  );
+  await child;
+});
+
+Deno.test("streaming api then non-streaming should error", async () => {
+  const child = $`echo 1 && echo 2`.stdout("piped").stderr("piped").spawn();
+  const stdout = readerFromStreamReader(child.stdout().getReader());
+  const stderr = readerFromStreamReader(child.stderr().getReader());
+  const result = await child;
+  // ensure these are all read to prevent issues with sanitizers
+  await readAll(stdout);
+  await readAll(stderr);
+
+  assertThrows(
+    () => {
+      result.stdout;
+    },
+    Error,
+    "Stdout was streamed to another source and is no longer available.",
+  );
+  assertThrows(
+    () => {
+      result.stderr;
+    },
+    Error,
+    "Stderr was streamed to another source and is no longer available.",
+  );
+});
+
+Deno.test("streaming api", async () => {
+  // stdout
+  {
+    const child = $`echo 1 && echo 2`.stdout("piped").spawn();
+    const text = await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+      .stdin(child.stdout())
+      .text();
+    assertEquals(text, "1\n2");
+  }
+
+  // stderr
+  {
+    const child = $`deno eval 'console.error(1); console.error(2)'`.stderr("piped").spawn();
+    const text = await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+      .stdin(child.stderr())
+      .text();
+    assertEquals(text, "1\n2");
+  }
+
+  // both
+  {
+    const child = $`deno eval 'console.log(1); setTimeout(() => console.error(2), 10)'`
+      .stdout("piped")
+      .stderr("piped")
+      .spawn();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        let hasClosed = false;
+        read(child.stdout().getReader());
+        read(child.stderr().getReader());
+
+        async function read(reader: ReadableStreamDefaultReader<Uint8Array>) {
+          while (true) {
+            const v = await reader.read();
+            if (v.value != null) {
+              controller.enqueue(v.value);
+            } else if (v.done) {
+              if (!hasClosed) {
+                controller.close();
+                hasClosed = true;
+              }
+              return;
+            }
+          }
+        }
+      },
+    });
+    const text = await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+      .stdin(stream)
+      .text();
+    assertEquals(text, "1\n2");
+  }
+});
+
+Deno.test("streaming api errors while streaming", async () => {
+  {
+    const child = $`echo 1 && echo 2 && exit 1`.stdout("piped").spawn();
+    const stdout = child.stdout();
+
+    // todo(THIS PR): this shouldn't be necessary... only surface this if someone
+    // subscribes to the promise (but only when piping obviously)
+    // prevent top level await
+    child.catch(() => {/* ignore */});
+
+    await assertRejects(
+      async () => {
+        await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+          .stdin(stdout)
+          .text();
+      },
+      Error,
+      "Exited with code: 1",
+    );
+  }
+
+  {
+    const child = $`echo 1 && echo 2 && sleep 0.1 && exit 1`.stdout("piped").spawn();
+    const stdout = child.stdout();
+
+    // todo(THIS PR): this shouldn't be necessary... only surface this if someone
+    // subscribes to the promise (but only when piping obviously)
+    // prevent top level await
+    child.catch(() => {/* ignore */});
+
+    const result = await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
+      .stdin(stdout)
+      .noThrow()
+      .stdout("piped")
+      .stderr("piped")
+      .spawn();
+    assertEquals(result.stderr, "stdin pipe broken. Error: Exited with code: 1\n");
+    assertEquals(result.stdout, "1\n2\n");
   }
 });
 

--- a/src/command_handler.ts
+++ b/src/command_handler.ts
@@ -17,6 +17,7 @@ export interface CommandContext {
   get stdin(): CommandPipeReader;
   get stdout(): CommandPipeWriter;
   get stderr(): CommandPipeWriter;
+  get signal(): AbortSignal;
 }
 
 /** Handler for executing a command. */

--- a/src/commands/sleep.ts
+++ b/src/commands/sleep.ts
@@ -1,10 +1,22 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult, getAbortedResult, resultFromCode } from "../result.ts";
 
 export async function sleepCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
     const ms = parseArgs(context.args);
-    await new Promise((resolve) => setTimeout(resolve, ms));
+    await new Promise<void>((resolve) => {
+      const timeoutId = setTimeout(listener, ms);
+      context.signal.addEventListener("abort", listener);
+
+      function listener() {
+        resolve();
+        clearInterval(timeoutId);
+        context.signal.removeEventListener("abort", listener);
+      }
+    });
+    if (context.signal.aborted) {
+      return getAbortedResult();
+    }
     return resultFromCode(0);
   } catch (err) {
     await context.stderr.writeLine(`sleep: ${err?.message ?? err}`);

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -4,6 +4,7 @@ export { Buffer } from "https://deno.land/std@0.171.0/io/buffer.ts";
 export { BufReader } from "https://deno.land/std@0.171.0/io/buf_reader.ts";
 export * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 export { readAll } from "https://deno.land/std@0.171.0/streams/read_all.ts";
+export { readerFromStreamReader } from "https://deno.land/std@0.171.0/streams/reader_from_stream_reader.ts";
 export { writeAllSync } from "https://deno.land/std@0.171.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
 export { outdent } from "https://deno.land/x/outdent@v0.8.0/src/index.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -5,7 +5,6 @@ export { BufReader } from "https://deno.land/std@0.171.0/io/buf_reader.ts";
 export * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 export { readAll } from "https://deno.land/std@0.171.0/streams/read_all.ts";
 export { readerFromStreamReader } from "https://deno.land/std@0.171.0/streams/reader_from_stream_reader.ts";
-export { readableStreamFromReader } from "https://deno.land/std@0.171.0/streams/readable_stream_from_reader.ts";
 export { writeAllSync } from "https://deno.land/std@0.171.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
 export { outdent } from "https://deno.land/x/outdent@v0.8.0/src/index.ts";

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -5,6 +5,7 @@ export { BufReader } from "https://deno.land/std@0.171.0/io/buf_reader.ts";
 export * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 export { readAll } from "https://deno.land/std@0.171.0/streams/read_all.ts";
 export { readerFromStreamReader } from "https://deno.land/std@0.171.0/streams/reader_from_stream_reader.ts";
+export { readableStreamFromReader } from "https://deno.land/std@0.171.0/streams/readable_stream_from_reader.ts";
 export { writeAllSync } from "https://deno.land/std@0.171.0/streams/write_all.ts";
 export { default as localDataDir } from "https://deno.land/x/dir@1.5.1/data_local_dir/mod.ts";
 export { outdent } from "https://deno.land/x/outdent@v0.8.0/src/index.ts";

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -91,10 +91,60 @@ export class InheritStaticTextBypassWriter implements Deno.WriterSync {
   }
 
   flush() {
-    const bytes = this.#buffer.bytes();
+    const bytes = this.#buffer.bytes({ copy: false });
     logger.logAboveStaticText(() => {
       writeAllSync(this.#innerWriter, bytes);
     });
     this.#buffer.reset();
+  }
+}
+
+export interface PipedBufferListener extends Deno.WriterSync, Deno.Closer {
+  setError(err: Error): void;
+}
+
+export class PipedBuffer implements Deno.WriterSync {
+  #inner: Buffer | PipedBufferListener;
+  #hasSet = false;
+
+  constructor() {
+    this.#inner = new Buffer();
+  }
+
+  getBuffer() {
+    if (this.#inner instanceof Buffer) {
+      return this.#inner;
+    } else {
+      return undefined;
+    }
+  }
+
+  setError(err: Error) {
+    if ("setError" in this.#inner) {
+      this.#inner.setError(err);
+    }
+  }
+
+  close() {
+    if ("close" in this.#inner) {
+      this.#inner.close();
+    }
+  }
+
+  writeSync(p: Uint8Array) {
+    return this.#inner.writeSync(p);
+  }
+
+  setListener(listener: PipedBufferListener) {
+    if (this.#hasSet) {
+      throw new Error("Piping to multiple outputs is currently not supported.");
+    }
+
+    if (this.#inner instanceof Buffer) {
+      writeAllSync(listener, this.#inner.bytes({ copy: false }));
+    }
+
+    this.#inner = listener;
+    this.#hasSet = true;
   }
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -8,6 +8,13 @@ export function resultFromCode(code: number): ContinueExecuteResult {
   };
 }
 
+export function getAbortedResult(): ExecuteResult {
+  return {
+    kind: "exit",
+    code: 124, // same as timeout command
+  };
+}
+
 /** Tells the shell it should exit immediately with the provided exit code. */
 export interface ExitExecuteResult {
   kind: "exit";

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -583,6 +583,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
     // have not finished before the process finished
     const _ignore = writeStdin(context.stdin, p, completeSignal)
       .catch((err) => {
+        context.stderr.writeLine(`stdin pipe broken. ${err}`);
         stdinError = err;
         // kill the sub process
         // todo(THIS PR): race condition here where the process doesn't exist? add some tests
@@ -596,7 +597,6 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
       readStderrTask,
     ]);
     if (stdinError != null) {
-      context.stderr.writeLine(`stdin pipe broken. ${stdinError}`);
       return {
         code: 1,
         kind: "exit",


### PR DESCRIPTION
Adds a new `CommandChild` struct that's returned from `.spawn()` that has `.stdout()` and `.stderr()` as well as `.abort()`.