### PR TITLE
fix: handle directory specified for pipeToPath

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -131,6 +131,17 @@ export async function lstat(path: string) {
     }
   }
 }
+export function lstatSync(path: string) {
+  try {
+    return Deno.lstatSync(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return undefined;
+    } else {
+      throw err;
+    }
+  }
+}
 
 export function getFileNameFromUrl(url: string | URL) {
   const parsedUrl = url instanceof URL ? url : new URL(url);

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -152,6 +152,16 @@ Deno.test("$.request", (t) => {
             Deno.errors.AlreadyExists,
           );
         }
+        {
+          // test downloading to a directory
+          const tempDir = Deno.makeTempDirSync();
+          const downloadedFilePath = await new RequestBuilder()
+            .url(new URL("/text-file", serverUrl))
+            .showProgress()
+            .pipeToPath(tempDir);
+          assertEquals(Deno.readTextFileSync(path.join(tempDir, "text-file")), "text".repeat(1000));
+          assertEquals(downloadedFilePath, path.join(tempDir, "text-file"));
+        }
       } finally {
         try {
           Deno.chdir(originDir);


### PR DESCRIPTION
wget errors in this case, I thought this is an intuitive behavior, not sure if there are disadvantages to this approach