### PR TITLE
fix: copy path resolution

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,6 +1,6 @@
 import { readAll } from "./src/deps.ts";
 import $, { build$, CommandBuilder, CommandContext, CommandHandler } from "./mod.ts";
-import { lstat, rustJoin } from "./src/common.ts";
+import { calculateDestinationPath, lstat } from "./src/common.ts";
 import { assert, assertEquals, assertRejects, assertStringIncludes, assertThrows } from "./src/deps.test.ts";
 import { Buffer, colors, path, readerFromStreamReader } from "./src/deps.ts";
 
@@ -1163,8 +1163,8 @@ Deno.test("copy test", async () => {
 
     assert($.existsSync(file1));
     assert($.existsSync(file2));
-    assert($.existsSync(rustJoin(destDir, file1)));
-    assert($.existsSync(rustJoin(destDir, file2)));
+    assert($.existsSync(calculateDestinationPath(destDir, file1)));
+    assert($.existsSync(calculateDestinationPath(destDir, file2)));
 
     const newFile = path.join(dir, "new.txt");
     Deno.writeTextFileSync(newFile, "test");
@@ -1172,7 +1172,7 @@ Deno.test("copy test", async () => {
 
     assert(await isDir(destDir));
     assert($.existsSync(newFile));
-    assert($.existsSync(rustJoin(destDir, newFile)));
+    assert($.existsSync(calculateDestinationPath(destDir, newFile)));
 
     assertEquals(
       await getStdErr($`cp ${file1} ${file2} non-existent`),
@@ -1236,8 +1236,8 @@ Deno.test("move test", async () => {
     await $`mv ${file1} ${file2} ${destDir}`;
     assert(!$.existsSync(file1));
     assert(!$.existsSync(file2));
-    assert($.existsSync(rustJoin(destDir, file2)));
-    assert($.existsSync(rustJoin(destDir, file2)));
+    assert($.existsSync(calculateDestinationPath(destDir, file2)));
+    assert($.existsSync(calculateDestinationPath(destDir, file2)));
 
     const newFile = path.join(dir, "new.txt");
     Deno.writeTextFileSync(newFile, "test");

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1203,6 +1203,7 @@ Deno.test("copy test", async () => {
     assertStringIncludes(await getStdErr($`cp -r ${destDir} ${destDir2}/file1.txt`), "destination was a file");
   });
 });
+
 Deno.test("cp test2", async () => {
   await withTempDir(async (dir) => {
     const originalDir = Deno.cwd();

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1203,6 +1203,21 @@ Deno.test("copy test", async () => {
     assertStringIncludes(await getStdErr($`cp -r ${destDir} ${destDir2}/file1.txt`), "destination was a file");
   });
 });
+Deno.test("cp test2", async () => {
+  await withTempDir(async (dir) => {
+    const originalDir = Deno.cwd();
+    try {
+      Deno.chdir(dir);
+      await $`mkdir -p a/d1`;
+      await $`mkdir -p a/d2`;
+      Deno.createSync("a/d1/f").close();
+      await $`cp a/d1/f a/d2`;
+      assert($.existsSync("a/d2/f"));
+    } finally {
+      Deno.chdir(originalDir);
+    }
+  });
+});
 
 Deno.test("move test", async () => {
   await withTempDir(async (dir) => {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,6 +1,6 @@
 import { readAll } from "./src/deps.ts";
 import $, { build$, CommandBuilder, CommandContext, CommandHandler } from "./mod.ts";
-import { calculateDestinationPath, lstat } from "./src/common.ts";
+import { lstat } from "./src/common.ts";
 import { assert, assertEquals, assertRejects, assertStringIncludes, assertThrows } from "./src/deps.test.ts";
 import { Buffer, colors, path, readerFromStreamReader } from "./src/deps.ts";
 
@@ -1163,8 +1163,8 @@ Deno.test("copy test", async () => {
 
     assert($.existsSync(file1));
     assert($.existsSync(file2));
-    assert($.existsSync(calculateDestinationPath(destDir, file1)));
-    assert($.existsSync(calculateDestinationPath(destDir, file2)));
+    assert($.existsSync(path.join(destDir, "file1.txt")));
+    assert($.existsSync(path.join(destDir, "file2.txt")));
 
     const newFile = path.join(dir, "new.txt");
     Deno.writeTextFileSync(newFile, "test");
@@ -1172,7 +1172,7 @@ Deno.test("copy test", async () => {
 
     assert(await isDir(destDir));
     assert($.existsSync(newFile));
-    assert($.existsSync(calculateDestinationPath(destDir, newFile)));
+    assert($.existsSync(path.join(destDir, "new.txt")));
 
     assertEquals(
       await getStdErr($`cp ${file1} ${file2} non-existent`),
@@ -1236,8 +1236,8 @@ Deno.test("move test", async () => {
     await $`mv ${file1} ${file2} ${destDir}`;
     assert(!$.existsSync(file1));
     assert(!$.existsSync(file2));
-    assert($.existsSync(calculateDestinationPath(destDir, file2)));
-    assert($.existsSync(calculateDestinationPath(destDir, file2)));
+    assert($.existsSync(path.join(destDir, "file1.txt")));
+    assert($.existsSync(path.join(destDir, "file2.txt")));
 
     const newFile = path.join(dir, "new.txt");
     Deno.writeTextFileSync(newFile, "test");

--- a/src/commands/cp_mv.ts
+++ b/src/commands/cp_mv.ts
@@ -2,6 +2,7 @@ import { CommandContext } from "../command_handler.ts";
 import { ExecuteResult, resultFromCode } from "../result.ts";
 import { bailUnsupported, parseArgKinds } from "./args.ts";
 import { lstat, resolvePath, rustJoin } from "../common.ts";
+import { path } from "../deps.ts";
 
 export async function cpCommand(
   context: CommandContext,
@@ -161,7 +162,11 @@ async function getCopyAndMoveOperations(
     }
   } else {
     const fromPath = resolvePath(cwd, fromArgs[0]);
-    const toPath = await lstat(destination).then((p) => p?.isDirectory) ? rustJoin(destination, fromPath) : destination;
+
+    const toPath = await lstat(destination).then((p) => p?.isDirectory)
+      ? (path.join(destination, path.basename(fromPath)))
+      : destination;
+
     operations.push({
       from: {
         specified: fromArgs[0],

--- a/src/common.ts
+++ b/src/common.ts
@@ -65,18 +65,15 @@ export function resolvePath(cwd: string, arg: string) {
   return path.resolve(path.isAbsolute(arg) ? arg : path.join(cwd, arg));
 }
 
-/**
- * Follow rust std::path::Path::join
- * The advantage is it can handle joining 2 absolute paths with common part
-
- * Rust: join("/a/b","/a/c") => "/a/b/c"
- * Deno. join("/a/b","/a/c") => "/a/b/a/c"
-**/
-export function rustJoin(path1: string, path2: string) {
-  const maybeCommon = path.common([path1, path2]);
-  if (!maybeCommon) return path.join(path1, path2);
-
-  return path.join(maybeCommon, path1.replace(maybeCommon, ""), path2.replace(maybeCommon, ""));
+/**  Calculates destination path
+ * destination should be a directory
+ * example:
+ *          destination: /dir/a
+ *          from       : /path/file
+ *          returns    : /dir/a/file
+ */
+export function calculateDestinationPath(destination: string, from: string) {
+  return path.join(destination, path.basename(from));
 }
 
 export class Box<T> {


### PR DESCRIPTION
The test case shows the problematic usage

This whole path manipulation is really fragile, I wonder if there is a guideline somewhere on how to handle this, at least in case of dax we have tests

Note: 
rustJoin in dax seems to have a different result then the actual rust join

rust
```rust
In: Path::new("/tmp/88032199/a/d2").join("/tmp/88032199/a/d1/f")
Out: "/tmp/88032199/a/d1/f"
```
deno: rustJoin
```ts
 rustJoin("/tmp/88032199/a/d2", "/tmp/88032199/a/d1/f")
"/tmp/88032199/a/d2/d1/f"
```

not sure if its important or not
