### PR TITLE
feat: support providing a delay to `RequestBuilder#timeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ const requestBuilder = new RequestBuilder()
 
 const result = await requestBuilder
   .url("https://example.com")
+  .timeout("10s")
   .text();
 ```
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -393,9 +393,9 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
    * Note that when using `.noThrow()` this won't cause an error to
    * be thrown when timing out.
    */
-  timeout(delay: Delay) {
+  timeout(delay: Delay | undefined) {
     return this.#newWithState((state) => {
-      state.timeout = delayToMs(delay);
+      state.timeout = delay == null ? undefined : delayToMs(delay);
     });
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,4 @@
-import { filterEmptyRecordValues, getFileNameFromUrl, lstatSync } from "./common.ts";
+import { Delay, delayToMs, filterEmptyRecordValues, getFileNameFromUrl, lstatSync } from "./common.ts";
 import { ProgressBar } from "./console/mod.ts";
 import { path } from "./deps.ts";
 
@@ -239,10 +239,10 @@ export class RequestBuilder implements PromiseLike<RequestResult> {
     });
   }
 
-  /** Timeout the request after the specified number of milliseconds */
-  timeout(ms: number | undefined) {
+  /** Timeout the request after the specified delay. */
+  timeout(delay: Delay | undefined) {
     return this.#newWithState((state) => {
-      state.timeout = ms;
+      state.timeout = delay == null ? undefined : delayToMs(delay);
     });
   }
 


### PR DESCRIPTION
Supports providing a string like:

```ts
const result = await requestBuilder
  .url("https://example.com")
  .timeout("10s")
  .text();
```