### PR TITLE
feat: add minutes and hours to `Delay` options

### DIFF
--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -17,6 +17,10 @@ Deno.test("should get delay value", () => {
   assertEquals(delayToMs(`10.123s`), 10_123);
   assertEquals(delayToMs(`10ms`), 10);
   assertEquals(delayToMs(`10000ms`), 10_000);
+  assertEquals(delayToMs(`1m`), 60 * 1000);
+  assertEquals(delayToMs(`1.5m`), 90 * 1000);
+  assertEquals(delayToMs(`2m`), 120 * 1000);
+  assertEquals(delayToMs(`2m10s`), 130 * 1000);
 });
 
 Deno.test("should get delay iterator", () => {
@@ -43,6 +47,9 @@ Deno.test("should format milliseconds", () => {
   assertEquals(formatMillis(1000), "1 second");
   assertEquals(formatMillis(2000), "2 seconds");
   assertEquals(formatMillis(1500), "1.5 seconds");
+  assertEquals(formatMillis(60_000), "1 minute");
+  assertEquals(formatMillis(61_000), "1.02 minutes");
+  assertEquals(formatMillis(92_000), "1.53 minutes");
 });
 
 Deno.test("should resolve absolute and relative paths", () => {

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -21,6 +21,7 @@ Deno.test("should get delay value", () => {
   assertEquals(delayToMs(`1.5m`), 90 * 1000);
   assertEquals(delayToMs(`2m`), 120 * 1000);
   assertEquals(delayToMs(`2m10s`), 130 * 1000);
+  assertEquals(delayToMs(`2.2m10.2s`), 142.2 * 1000);
 });
 
 Deno.test("should get delay iterator", () => {

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -22,6 +22,10 @@ Deno.test("should get delay value", () => {
   assertEquals(delayToMs(`2m`), 120 * 1000);
   assertEquals(delayToMs(`2m10s`), 130 * 1000);
   assertEquals(delayToMs(`2.2m10.2s`), 142.2 * 1000);
+  assertEquals(delayToMs(`1h`), 1000 * 60 * 60);
+  assertEquals(delayToMs(`1.5h`), 1.5 * 1000 * 60 * 60);
+  assertEquals(delayToMs(`1.2h11m`), 1.2 * 1000 * 60 * 60 + 11 * 1000 * 60);
+  assertEquals(delayToMs(`1.1h50.2m20.1s`), 1.1 * 1000 * 60 * 60 + 50.2 * 1000 * 60 + 20.1 * 1000);
 });
 
 Deno.test("should get delay iterator", () => {

--- a/src/common.ts
+++ b/src/common.ts
@@ -6,7 +6,15 @@ import { BufReader, path } from "./deps.ts";
  *
  * @remarks Providing just a number will use milliseconds.
  */
-export type Delay = number | `${number}ms` | `${number}s` | `${number}m` | `${number}m${number}s`;
+export type Delay =
+  | number
+  | `${number}ms`
+  | `${number}s`
+  | `${number}m`
+  | `${number}m${number}s`
+  | `${number}h`
+  | `${number}h${number}m`
+  | `${number}h${number}m${number}s`;
 
 /** An iterator that returns a new delay each time. */
 export interface DelayIterator {
@@ -57,6 +65,7 @@ export function delayToMs(delay: Delay) {
   if (typeof delay === "number") {
     return delay;
   } else if (typeof delay === "string") {
+    // code seems kind of repetitive
     const msMatch = delay.match(/^([0-9]+)ms$/);
     if (msMatch != null) {
       return parseInt(msMatch[1], 10);
@@ -74,6 +83,25 @@ export function delayToMs(delay: Delay) {
       return Math.round(
         parseFloat(minutesSecondsMatch[1]) * 1000 * 60 +
           parseFloat(minutesSecondsMatch[2]) * 1000,
+      );
+    }
+    const hoursMatch = delay.match(/^([0-9]+\.?[0-9]*)h$/);
+    if (hoursMatch != null) {
+      return Math.round(parseFloat(hoursMatch[1]) * 1000 * 60 * 60);
+    }
+    const hoursMinutesMatch = delay.match(/^([0-9]+\.?[0-9]*)h([0-9]+\.?[0-9]*)m$/);
+    if (hoursMinutesMatch != null) {
+      return Math.round(
+        parseFloat(hoursMinutesMatch[1]) * 1000 * 60 * 60 +
+          parseFloat(hoursMinutesMatch[2]) * 1000 * 60,
+      );
+    }
+    const hoursMinutesSecondsMatch = delay.match(/^([0-9]+\.?[0-9]*)h([0-9]+\.?[0-9]*)m([0-9]+\.?[0-9]*)s$/);
+    if (hoursMinutesSecondsMatch != null) {
+      return Math.round(
+        parseFloat(hoursMinutesSecondsMatch[1]) * 1000 * 60 * 60 +
+          parseFloat(hoursMinutesSecondsMatch[2]) * 1000 * 60 +
+          parseFloat(hoursMinutesSecondsMatch[3]) * 1000,
       );
     }
   }


### PR DESCRIPTION
You can now provide values like:

- `timeout("1m")`
- `timeout("2m10s")`
- `timeout("1.5h")`
- `timeout("2h10m")`
- `timeout("2h5m20s")`