### PR TITLE
fix(rm): ignore `NotFound` errors when `--force` flag is set

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1085,11 +1085,13 @@ Deno.test("test remove", async () => {
     Deno.mkdirSync(emptyDir);
     Deno.writeTextFileSync(someFile, "");
 
+    // Remove empty directory or file
     await $`rm ${emptyDir}`;
     await $`rm ${someFile}`;
     assertEquals($.existsSync(dir + "/hello"), false);
     assertEquals($.existsSync(dir + "/a.txt"), false);
 
+    // Remove a non-empty directory
     const nonEmptyDir = dir + "/a";
     Deno.mkdirSync(nonEmptyDir + "/b", { recursive: true });
     {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1113,7 +1113,7 @@ Deno.test("test remove", async () => {
         .then((r) => r.stderr);
       const expectedText = Deno.build.os === "linux" || Deno.build.os === "darwin"
         ? "rm: No such file or directory"
-        : "rm: The system cannot find the path specified";
+        : "rm: The system cannot find the file specified";
       assertEquals(error.substring(0, expectedText.length), expectedText);
     }
     {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1113,7 +1113,7 @@ Deno.test("test remove", async () => {
         .then((r) => r.stderr);
       const expectedText = Deno.build.os === "linux" || Deno.build.os === "darwin"
         ? "rm: No such file or directory"
-        : "rm: No such file or directory"; // <--- not sure what the windows error will be.
+        : "rm: The system cannot find the path specified";
       assertEquals(error.substring(0, expectedText.length), expectedText);
     }
     {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1109,17 +1109,19 @@ Deno.test("test remove", async () => {
 
     // Remove a directory that does not exist
     {
-      const error = await $`rm ${notExists}`.noThrow().stderr("piped").spawn()
-        .then((r) => r.stderr);
+      const [error, code] = await $`rm ${notExists}`.noThrow().stderr("piped").spawn()
+        .then((r) => [r.stderr, r.code] as const);
       const expectedText = Deno.build.os === "linux" || Deno.build.os === "darwin"
         ? "rm: No such file or directory"
         : "rm: The system cannot find the file specified";
       assertEquals(error.substring(0, expectedText.length), expectedText);
+      assertEquals(code, 1);
     }
     {
-      const error = await $`rm -Rf ${notExists}`.noThrow().stderr("piped").spawn()
-        .then((r) => r.stderr);
+      const [error, code] = await $`rm -Rf ${notExists}`.noThrow().stderr("piped").spawn()
+        .then((r) => [r.stderr, r.code] as const);
       assertEquals(error, "");
+      assertEquals(code, 0);
     }
   });
 });

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -26,17 +26,13 @@ async function executeRemove(cwd: string, args: string[]) {
   const flags = parseArgs(args);
   await Promise.all(flags.paths.map((specifiedPath) => {
     if (specifiedPath.length === 0) {
-      throw new Error(
-        "Bug in dax. Specified path should have not been empty.",
-      );
+      throw new Error("Bug in dax. Specified path should have not been empty.");
     }
 
     const path = resolvePath(cwd, specifiedPath);
     if (path === "/") {
       // just in case...
-      throw new Error(
-        "Cannot delete root directory. Maybe bug in dax? Please report this.",
-      );
+      throw new Error("Cannot delete root directory. Maybe bug in dax? Please report this.");
     }
 
     // return Deno.remove(path, { recursive: flags.recursive })

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -35,7 +35,6 @@ async function executeRemove(cwd: string, args: string[]) {
       throw new Error("Cannot delete root directory. Maybe bug in dax? Please report this.");
     }
 
-    // return Deno.remove(path, { recursive: flags.recursive })
     return Deno.remove(path, { recursive: flags.recursive }).catch((err) => {
       if (flags.force && err instanceof Deno.errors.NotFound) {
         return Promise.resolve();

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -24,31 +24,30 @@ interface RmFlags {
 
 async function executeRemove(cwd: string, args: string[]) {
   const flags = parseArgs(args);
-  try {
-    await Promise.all(flags.paths.map((specifiedPath) => {
-      if (specifiedPath.length === 0) {
-        throw new Error(
-          "Bug in dax. Specified path should have not been empty.",
-        );
-      }
-
-      const path = resolvePath(cwd, specifiedPath);
-      if (path === "/") {
-        // just in case...
-        throw new Error(
-          "Cannot delete root directory. Maybe bug in dax? Please report this.",
-        );
-      }
-
-      return Deno.remove(path, { recursive: flags.recursive });
-    }));
-  } catch (err) {
-    if (flags.force && err instanceof Deno.errors.NotFound) {
-      return;
+  await Promise.all(flags.paths.map((specifiedPath) => {
+    if (specifiedPath.length === 0) {
+      throw new Error(
+        "Bug in dax. Specified path should have not been empty.",
+      );
     }
 
-    throw err;
-  }
+    const path = resolvePath(cwd, specifiedPath);
+    if (path === "/") {
+      // just in case...
+      throw new Error(
+        "Cannot delete root directory. Maybe bug in dax? Please report this.",
+      );
+    }
+
+    // return Deno.remove(path, { recursive: flags.recursive })
+    return Deno.remove(path, { recursive: flags.recursive }).catch((err) => {
+      if (flags.force && err instanceof Deno.errors.NotFound) {
+        return Promise.resolve();
+      } else {
+        return Promise.reject(err);
+      }
+    });
+  }));
 }
 
 export function parseArgs(args: string[]) {


### PR DESCRIPTION
This PR adds a try/catch inside `executeRemove` and ignores NotFound errors when `force` is set.

This is inline with the behavior of `rm -Rf` on Unix.