### PR TITLE
refactor: remove `$.exists/existsSync(...)` - Use `$.path(...).existsSync()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,20 +522,12 @@ $.cd("someDir");
 console.log(Deno.cwd()); // will be in someDir directory
 ```
 
-Checking if a path exists:
-
-```ts
-// Note: beware of "time of check to time of use" race conditions when using this
-await $.exists("./file.txt");
-$.existsSync("./file.txt");
-```
-
 Sleeping asynchronously for a specified amount of time:
 
 ```ts
 await $.sleep(100); // ms
 await $.sleep("1.5s");
-await $.sleep("100ms");
+await $.sleep("1m30s");
 ```
 
 Getting path to an executable based on a command name:

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1131,7 +1131,7 @@ Deno.test("test remove", async () => {
 Deno.test("test mkdir", async () => {
   await withTempDir(async (dir) => {
     await $`mkdir ${dir}/a`;
-    await $.exists(dir + "/a");
+    assert(dir.join("a").existsSync());
 
     {
       const error = await $`mkdir ${dir}/a`.noThrow().stderr("piped").spawn()
@@ -1154,7 +1154,7 @@ Deno.test("test mkdir", async () => {
     }
 
     await $`mkdir -p ${dir}/b/c`;
-    assert(await $.exists(dir + "/b/c"));
+    assert(await dir.join("b/c").exists());
   });
 });
 
@@ -1216,12 +1216,12 @@ Deno.test("copy test", async () => {
 });
 
 Deno.test("cp test2", async () => {
-  await withTempDir(async () => {
+  await withTempDir(async (dir) => {
     await $`mkdir -p a/d1`;
     await $`mkdir -p a/d2`;
     Deno.createSync("a/d1/f").close();
     await $`cp a/d1/f a/d2`;
-    assert($.existsSync("a/d2/f"));
+    assert(dir.join("a/d2/f").existsSync());
   });
 });
 
@@ -1339,15 +1339,15 @@ Empty lines (like the one above) will not affect the common indentation.`.trim()
 });
 
 Deno.test("touch test", async () => {
-  await withTempDir(async () => {
+  await withTempDir(async (dir) => {
     await $`touch a`;
-    assert($.existsSync("a"));
+    assert(dir.join("a").existsSync());
     await $`touch a`;
-    assert($.existsSync("a"));
+    assert(dir.join("a").existsSync());
 
     await $`touch b c`;
-    assert($.existsSync("b"));
-    assert($.existsSync("c"));
+    assert(dir.join("b").existsSync());
+    assert(dir.join("c").existsSync());
 
     assertEquals(await getStdErr($`touch`), "touch: missing file operand\n");
 

--- a/mod.ts
+++ b/mod.ts
@@ -206,17 +206,6 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    */
   dedent: typeof outdent;
   /**
-   * Gets if the provided path exists asynchronously.
-   *
-   * Although there is a potential for a race condition between the
-   * time this check is made and the time some code is used, it may
-   * not be a big deal to use this in some scenarios and simplify
-   * the code a lot.
-   */
-  exists(path: string): Promise<boolean>;
-  /** Gets if the provided path exists synchronously. */
-  existsSync(path: string): boolean;
-  /**
    * Determines if the provided command exists resolving to `true` if the command
    * will be resolved by the shell of the current `$` or false otherwise.
    */
@@ -548,12 +537,6 @@ const helperObject = {
     return wasmInstance.strip_ansi_codes(text);
   },
   dedent: outdent,
-  exists(path: string) {
-    return fs.exists(path);
-  },
-  existsSync(path: string) {
-    return fs.existsSync(path);
-  },
   sleep,
   which(commandName: string) {
     if (commandName.toUpperCase() === "DENO") {


### PR DESCRIPTION
The new path API is much better so this isn't necessary anymore.