### PR TITLE
perf(path_ref): cache if the path is known to be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ pb.with(() => {
 
 ## Path API
 
-The path API offers an immutable `PathRef` class, which is a similar concept to Rust's `PathBuf` struct.
+The path API offers an immutable [`PathRef`](https://deno.land/x/dax/src/path.ts?s=PathRef) class, which is a similar concept to Rust's `PathBuf` struct.
 
 ```ts
 // create a `PathRef`

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -73,6 +73,16 @@ Deno.test("ancestors", () => {
   }
 });
 
+Deno.test("resolve", () => {
+  // there are more tests elsewhere
+  const srcDir = createPathRef("src").resolve();
+  const assetsDir = srcDir.resolve("assets");
+  assert(assetsDir.toString().endsWith("assets"));
+
+  // should be the same object since it is known to be resolved
+  assert(assetsDir === assetsDir.resolve());
+});
+
 Deno.test("stat", async () => {
   const stat1 = await createPathRef("src").stat();
   assertEquals(stat1?.isDirectory, true);


### PR DESCRIPTION
This stores a boolean in the path ref to know that it's resolved. It's about 200ns faster on a short path I measured (will be even faster for longer paths) and returns back `this` when the current `PathRef` is already resolved and no path segments are provided.