### PR TITLE
feat: `PathRef` - make `mkdir` recursive by default

### DIFF
--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -214,14 +214,14 @@ Deno.test("mkdir", async () => {
     path.mkdirSync();
     assert(path.isDir());
     const nestedDir = path.join("subdir", "subsubdir", "sub");
-    await assertRejects(() => nestedDir.mkdir());
-    assertThrows(() => nestedDir.mkdirSync());
+    await assertRejects(() => nestedDir.mkdir({ recursive: false }));
+    assertThrows(() => nestedDir.mkdirSync({ recursive: false }));
     assert(!nestedDir.parentOrThrow().existsSync());
-    await nestedDir.mkdir({ recursive: true });
+    await nestedDir.mkdir();
     assert(nestedDir.existsSync());
     await path.remove({ recursive: true });
     assert(!path.existsSync());
-    nestedDir.mkdirSync({ recursive: true });
+    nestedDir.mkdirSync();
     assert(nestedDir.existsSync());
   });
 });
@@ -288,7 +288,7 @@ Deno.test("expandGlob", async () => {
     dir.join("file1").writeTextSync("");
     dir.join("file2").writeTextSync("");
     const subDir = dir.join("dir").join("subDir");
-    subDir.mkdirSync({ recursive: true });
+    subDir.mkdirSync();
     subDir.join("file.txt").writeTextSync("");
 
     const entries1 = [];

--- a/src/path.ts
+++ b/src/path.ts
@@ -270,15 +270,25 @@ export class PathRef {
     };
   }
 
-  /** Creates a directory at this path. */
+  /** Creates a directory at this path.
+   * @remarks By default, this is recursive.
+   */
   async mkdir(options?: Deno.MkdirOptions): Promise<this> {
-    await Deno.mkdir(this.#path, options);
+    await Deno.mkdir(this.#path, {
+      recursive: true,
+      ...options,
+    });
     return this;
   }
 
-  /** Synchronously creates a directory at this path. */
+  /** Synchronously creates a directory at this path.
+   * @remarks By default, this is recursive.
+   */
   mkdirSync(options?: Deno.MkdirOptions): this {
-    Deno.mkdirSync(this.#path, options);
+    Deno.mkdirSync(this.#path, {
+      recursive: true,
+      ...options,
+    });
     return this;
   }
 


### PR DESCRIPTION
It's easier when this is recursive by default.

Note: We should not make `remove` recursive by default though because we don't want to accidentally delete more than we should.