### PR TITLE
feat: `PathRef` - support creating via `import.meta` and file url strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,16 @@ const srcDir = $.path("src").resolve();
 await $`echo ${srcDir}`;
 ```
 
+`PathRef`s can be created in the following ways:
+
+```ts
+const pathRelative = $.path("./relative");
+const pathAbsolute = $.path("/tmp");
+const pathFileUrl = $.path(new URL("file:///test")); // converts to /test
+const pathStringFileUrl = $.path("file:///test"); // converts to /test
+const pathImportMeta = $.path(import.meta); // the path for the current module
+```
+
 There are a lot of helper methods here, so check the [documentation on PathRef](https://deno.land/x/dax/src/path.ts?s=PathRef) for more details.
 
 ## Helper functions

--- a/README.md
+++ b/README.md
@@ -519,8 +519,8 @@ await $`echo ${srcDir}`;
 ```ts
 const pathRelative = $.path("./relative");
 const pathAbsolute = $.path("/tmp");
-const pathFileUrl = $.path(new URL("file:///test")); // converts to /test
-const pathStringFileUrl = $.path("file:///test"); // converts to /test
+const pathFileUrl = $.path(new URL("file:///tmp")); // converts to /tmp
+const pathStringFileUrl = $.path("file:///tmp"); // converts to /tmp
 const pathImportMeta = $.path(import.meta); // the path for the current module
 ```
 

--- a/mod.ts
+++ b/mod.ts
@@ -221,7 +221,10 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
   fs: typeof fs;
   /** Helper function for creating path references, which provide an easier way for
    * working with paths, directories, and files on the file system. Also, a re-export
-   * of deno_std's `path` module as properties on this object. */
+   * of deno_std's `path` module as properties on this object.
+   *
+   * The function creates a new `PathRef` from a path or URL string, file URL, or for the current module.
+   */
   path: typeof createPathRef & typeof stdPath;
   /**
    * Logs with potential indentation (`$.logIndent`)

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -580,8 +580,8 @@ Deno.test("instanceof check", () => {
   assert(createPathRef("test") instanceof OtherPathRef);
 });
 
-Deno.test("toFileURL", () => {
+Deno.test("toFileUrl", () => {
   const path = createPathRef(import.meta);
   assertEquals(path.toString(), stdPath.fromFileUrl(import.meta.url));
-  assertEquals(path.toFileURL(), new URL(import.meta.url));
+  assertEquals(path.toFileUrl(), new URL(import.meta.url));
 });

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -579,3 +579,9 @@ Deno.test("instanceof check", () => {
   assert(new OtherPathRef() instanceof PathRef);
   assert(createPathRef("test") instanceof OtherPathRef);
 });
+
+Deno.test("toFileURL", () => {
+  const path = createPathRef(import.meta);
+  assertEquals(path.toString(), stdPath.fromFileUrl(import.meta.url));
+  assertEquals(path.toFileURL(), new URL(import.meta.url));
+});

--- a/src/path.ts
+++ b/src/path.ts
@@ -2,7 +2,7 @@ import { fs, path as stdPath, writeAll, writeAllSync } from "./deps.ts";
 
 const PERIOD_CHAR_CODE = ".".charCodeAt(0);
 
-export function createPathRef(path: string | URL): PathRef {
+export function createPathRef(path: string | URL | ImportMeta): PathRef {
   return new PathRef(path);
 }
 
@@ -27,8 +27,18 @@ export class PathRef {
    */
   private static instanceofSymbol = Symbol.for("dax.PathRef");
 
-  constructor(path: string | URL) {
-    this.#path = path instanceof URL ? stdPath.fromFileUrl(path) : path;
+  constructor(path: string | URL | ImportMeta) {
+    if (path instanceof URL) {
+      this.#path = stdPath.fromFileUrl(path);
+    } else if (typeof path === "string") {
+      if (path.startsWith("file://")) {
+        this.#path = stdPath.fromFileUrl(path);
+      } else {
+        this.#path = path;
+      }
+    } else {
+      this.#path = stdPath.fromFileUrl(path.url);
+    }
   }
 
   /** @internal */
@@ -40,6 +50,12 @@ export class PathRef {
   /** Gets the string representation of this path. */
   toString(): string {
     return this.#path;
+  }
+
+  /** Resolves the path and gets the file URL. */
+  toFileURL(): URL {
+    const resolvedPath = this.resolve();
+    return stdPath.toFileUrl(resolvedPath.toString());
   }
 
   /** Joins the provided path segments onto this path. */

--- a/src/path.ts
+++ b/src/path.ts
@@ -53,7 +53,7 @@ export class PathRef {
   }
 
   /** Resolves the path and gets the file URL. */
-  toFileURL(): URL {
+  toFileUrl(): URL {
     const resolvedPath = this.resolve();
     return stdPath.toFileUrl(resolvedPath.toString());
   }


### PR DESCRIPTION
Noticed this while reviewing a PR.