### PR TITLE
feat: PathRef - simplify symlink creation functions

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -31,7 +31,7 @@ import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { createPathRef, PathRef } from "./src/path.ts";
 
 export { FsFileWrapper, PathRef } from "./src/path.ts";
-export type { WalkEntry } from "./src/path.ts";
+export type { SymlinkOptions, WalkEntry } from "./src/path.ts";
 export { CommandBuilder, CommandResult } from "./src/command.ts";
 export type { CommandContext, CommandHandler, CommandPipeReader, CommandPipeWriter } from "./src/command_handler.ts";
 export type {

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -130,7 +130,8 @@ Deno.test("lstat", async () => {
   await withTempDir(async () => {
     const symlinkFile = createPathRef("temp.txt");
     const otherFile = createPathRef("other.txt").writeTextSync("");
-    await symlinkFile.createSymlinkToAsRelative(otherFile);
+    // path ref
+    await symlinkFile.createSymlinkTo(otherFile);
     const stat3 = await symlinkFile.lstat();
     assertEquals(stat3!.isSymlink, true);
   });
@@ -145,9 +146,25 @@ Deno.test("lstatSync", async () => {
   await withTempDir(() => {
     const symlinkFile = createPathRef("temp.txt");
     const otherFile = createPathRef("other.txt").writeTextSync("");
-    symlinkFile.createSymlinkToAsRelativeSync(otherFile);
-    const stat3 = symlinkFile.lstatSync();
-    assertEquals(stat3!.isSymlink, true);
+
+    // path ref
+    symlinkFile.createSymlinkToSync(otherFile);
+    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
+
+    // path ref absolute
+    symlinkFile.removeSync();
+    symlinkFile.createSymlinkToSync(otherFile, { kind: "absolute" });
+    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
+
+    // path ref relative
+    symlinkFile.removeSync();
+    symlinkFile.createSymlinkToSync(otherFile, { kind: "relative" });
+    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
+
+    // relative text
+    symlinkFile.removeSync();
+    symlinkFile.createSymlinkToSync("other.txt");
+    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
   });
 });
 

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -39,7 +39,8 @@ Deno.test("isFile", () => {
 Deno.test("isSymlink", async () => {
   await withTempDir(() => {
     const file = createPathRef("file.txt").writeTextSync("");
-    const symlinkFile = createPathRef("test.txt").createSymlinkToSync(file);
+    const symlinkFile = createPathRef("test.txt");
+    symlinkFile.createSymlinkToSync(file);
     assert(symlinkFile.isSymlink());
     assert(!file.isSymlink());
   });

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -146,24 +146,7 @@ Deno.test("lstatSync", async () => {
   await withTempDir(() => {
     const symlinkFile = createPathRef("temp.txt");
     const otherFile = createPathRef("other.txt").writeTextSync("");
-
-    // path ref
     symlinkFile.createSymlinkToSync(otherFile);
-    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
-
-    // path ref absolute
-    symlinkFile.removeSync();
-    symlinkFile.createSymlinkToSync(otherFile, { kind: "absolute" });
-    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
-
-    // path ref relative
-    symlinkFile.removeSync();
-    symlinkFile.createSymlinkToSync(otherFile, { kind: "relative" });
-    assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
-
-    // relative text
-    symlinkFile.removeSync();
-    symlinkFile.createSymlinkToSync("other.txt");
     assertEquals(symlinkFile.lstatSync()!.isSymlink, true);
   });
 });
@@ -257,24 +240,41 @@ Deno.test("mkdir", async () => {
 Deno.test("createSymlinkTo", async () => {
   await withTempDir(async () => {
     const destFile = createPathRef("temp.txt").writeTextSync("");
-    const otherFile = destFile.parentOrThrow().join("other.txt");
-    await otherFile.createSymlinkTo(destFile);
-    const stat = await otherFile.stat();
+    const symlinkFile = destFile.parentOrThrow().join("other.txt");
+    await symlinkFile.createSymlinkTo(destFile);
+    const stat = await symlinkFile.stat();
     assertEquals(stat!.isFile, true);
     assertEquals(stat!.isSymlink, false);
-    assert(otherFile.isSymlink());
+    assert(symlinkFile.isSymlink());
   });
 });
 
 Deno.test("createSymlinkToSync", async () => {
   await withTempDir(() => {
     const destFile = createPathRef("temp.txt").writeTextSync("");
-    const otherFile = destFile.parentOrThrow().join("other.txt");
-    otherFile.createSymlinkToSync(destFile);
-    const stat = otherFile.statSync();
+    const symlinkFile = destFile.parentOrThrow().join("other.txt");
+
+    // path ref
+    symlinkFile.createSymlinkToSync(destFile);
+    const stat = symlinkFile.statSync();
     assertEquals(stat!.isFile, true);
     assertEquals(stat!.isSymlink, false);
-    assert(otherFile.isSymlink());
+    assert(symlinkFile.isSymlink());
+
+    // path ref absolute
+    symlinkFile.removeSync();
+    symlinkFile.createSymlinkToSync(destFile, { kind: "absolute" });
+    assertEquals(symlinkFile.statSync()!.isFile, true);
+
+    // path ref relative
+    symlinkFile.removeSync();
+    symlinkFile.createSymlinkToSync(destFile, { kind: "relative" });
+    assertEquals(symlinkFile.statSync()!.isFile, true);
+
+    // relative text
+    symlinkFile.removeSync();
+    symlinkFile.createSymlinkToSync("temp.txt");
+    assertEquals(symlinkFile.statSync()!.isFile, true);
   });
 });
 

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -121,7 +121,7 @@ Deno.test("lstat", async () => {
 
   await withTempDir(async () => {
     const dir = createPathRef("temp.txt").writeTextSync("");
-    const destinationPath = await dir.createRelativeSymlinkAt("other.txt");
+    const destinationPath = await dir.createSymlinkRelativeTo("other.txt");
     const stat3 = await destinationPath.lstat();
     assertEquals(stat3!.isSymlink, true);
   });
@@ -135,7 +135,7 @@ Deno.test("lstatSync", async () => {
 
   await withTempDir(() => {
     const dir = createPathRef("temp.txt").writeTextSync("");
-    const destinationPath = dir.createRelativeSymlinkAtSync("other.txt");
+    const destinationPath = dir.createSymlinkRelativeToSync("other.txt");
     const stat3 = destinationPath.lstatSync();
     assertEquals(stat3!.isSymlink, true);
   });
@@ -226,11 +226,11 @@ Deno.test("mkdir", async () => {
   });
 });
 
-Deno.test("createAbsoluteSymlinkTo", async () => {
+Deno.test("createSymlinkTo", async () => {
   await withTempDir(async () => {
     const destFile = createPathRef("temp.txt").writeTextSync("");
     const otherFile = destFile.parentOrThrow().join("other.txt");
-    await otherFile.createAbsoluteSymlinkTo(destFile);
+    await otherFile.createSymlinkTo(destFile);
     const stat = await otherFile.stat();
     assertEquals(stat!.isFile, true);
     assertEquals(stat!.isSymlink, false);
@@ -238,11 +238,11 @@ Deno.test("createAbsoluteSymlinkTo", async () => {
   });
 });
 
-Deno.test("createAbsoluteSymlinkToSync", async () => {
+Deno.test("createSymlinkToSync", async () => {
   await withTempDir(() => {
     const destFile = createPathRef("temp.txt").writeTextSync("");
     const otherFile = destFile.parentOrThrow().join("other.txt");
-    otherFile.createAbsoluteSymlinkToSync(destFile);
+    otherFile.createSymlinkToSync(destFile);
     const stat = otherFile.statSync();
     assertEquals(stat!.isFile, true);
     assertEquals(stat!.isSymlink, false);

--- a/src/path.ts
+++ b/src/path.ts
@@ -347,10 +347,18 @@ export class PathRef {
     }
     const targetPath = ensurePathRef(target).resolve();
     if (opts?.kind === "relative") {
+      const fromPath = this.resolve();
+      let relativePath: string;
+      if (fromPath.dirname() === targetPath.dirname()) {
+        // we don't want it to do `../basename`
+        relativePath = targetPath.basename();
+      } else {
+        relativePath = fromPath.relative(targetPath);
+      }
       return {
-        fromPath: this.resolve(),
+        fromPath,
         targetPath,
-        text: this.relative(targetPath),
+        text: relativePath,
         type: opts?.type,
       };
     } else {

--- a/src/path.ts
+++ b/src/path.ts
@@ -311,7 +311,7 @@ export class PathRef {
   /**
    * Creates a symlink at the provided path to the provided target returning the target path.
    */
-  async createAbsoluteSymlinkTo(
+  async createSymlinkTo(
     target: string | URL | PathRef,
     opts?: Deno.SymlinkOptions,
   ): Promise<PathRef> {
@@ -330,7 +330,7 @@ export class PathRef {
    * Synchronously creates a symlink at the provided path to the provided target returning the target path.
    * @returns The resolved target path.
    */
-  createAbsoluteSymlinkToSync(target: string | URL | PathRef, opts?: Deno.SymlinkOptions): PathRef {
+  createSymlinkToSync(target: string | URL | PathRef, opts?: Deno.SymlinkOptions): PathRef {
     const from = this.resolve();
     const to = ensurePathRef(target).resolve();
     createSymlinkSync({
@@ -390,7 +390,7 @@ export class PathRef {
    * @param linkPath The path to create a symlink at which points at the current path.
    * @returns The destination path.
    */
-  async createRelativeSymlinkAt(
+  async createSymlinkRelativeTo(
     linkPath: string | URL | PathRef,
     opts?: Deno.SymlinkOptions,
   ): Promise<PathRef> {
@@ -414,7 +414,7 @@ export class PathRef {
    * @param linkPath The path to create a symlink at which points at the current path.
    * @returns The destination path.
    */
-  createRelativeSymlinkAtSync(
+  createSymlinkRelativeToSync(
     linkPath: string | URL | PathRef,
     opts?: Deno.SymlinkOptions,
   ): PathRef {

--- a/src/path.ts
+++ b/src/path.ts
@@ -318,7 +318,7 @@ export class PathRef {
   async createSymlinkTo(
     target: string | URL | PathRef,
     opts?: Deno.SymlinkOptions,
-  ): Promise<this> {
+  ): Promise<void> {
     const from = this.resolve();
     const to = ensurePathRef(target).resolve();
     await createSymlink({
@@ -327,13 +327,12 @@ export class PathRef {
       text: to.#path,
       type: opts?.type,
     });
-    return this;
   }
 
   /**
    * Synchronously creates a symlink at the provided path to the provided target returning the target path.
    */
-  createSymlinkToSync(target: string | URL | PathRef, opts?: Deno.SymlinkOptions): this {
+  createSymlinkToSync(target: string | URL | PathRef, opts?: Deno.SymlinkOptions): void {
     const from = this.resolve();
     const to = ensurePathRef(target).resolve();
     createSymlinkSync({
@@ -342,7 +341,6 @@ export class PathRef {
       text: to.#path,
       type: opts?.type,
     });
-    return this;
   }
 
   /**
@@ -353,7 +351,7 @@ export class PathRef {
   async createSymlinkToAsRelative(
     linkPath: string | URL | PathRef,
     opts?: Deno.SymlinkOptions,
-  ): Promise<this> {
+  ): Promise<void> {
     const {
       linkPathRef,
       thisResolved,
@@ -365,7 +363,6 @@ export class PathRef {
       text: relativePath,
       type: opts?.type,
     });
-    return this;
   }
 
   /**
@@ -376,7 +373,7 @@ export class PathRef {
   createSymlinkToAsRelativeSync(
     linkPath: string | URL | PathRef,
     opts?: Deno.SymlinkOptions,
-  ): this {
+  ): void {
     const {
       linkPathRef,
       thisResolved,
@@ -388,7 +385,6 @@ export class PathRef {
       text: relativePath,
       type: opts?.type,
     });
-    return this;
   }
 
   #getSymlinkToAsRelativeParts(linkPath: string | URL | PathRef) {


### PR DESCRIPTION
Removes all symlink creation functions and replaces them with a single `createSymlinkTo`/`createSymlinkToSync` function.

Closes https://github.com/dsherret/dax/issues/115