### PR TITLE
feat: `PathRef.prototype.createSymlinkTo` - require specifying if absolute or relative for `PathRef` and `URL` args

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -31,7 +31,7 @@ import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { createPathRef, PathRef } from "./src/path.ts";
 
 export { FsFileWrapper, PathRef } from "./src/path.ts";
-export type { SymlinkOptions, WalkEntry } from "./src/path.ts";
+export type { PathSymlinkOptions, SymlinkOptions, WalkEntry } from "./src/path.ts";
 export { CommandBuilder, CommandResult } from "./src/command.ts";
 export type { CommandContext, CommandHandler, CommandPipeReader, CommandPipeWriter } from "./src/command_handler.ts";
 export type {

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -252,11 +252,11 @@ Deno.test("createSymlinkTo", async () => {
     // invalid
     await assertRejects(
       async () => {
-        // @ts-expect-error
+        // @ts-expect-error should require an options bag
         await symlinkFile.createSymlinkTo(destFile);
       },
       Error,
-      "Please specify if this symlink is absolute or relative. Otherwise, provide the target text.",
+      "Please specify if this symlink is absolute or relative. Otherwise provide the target text.",
     );
   });
 });
@@ -291,11 +291,11 @@ Deno.test("createSymlinkToSync", async () => {
     // invalid
     assertThrows(
       () => {
-        // @ts-expect-error
+        // @ts-expect-error should require an options bag
         symlinkFile.createSymlinkToSync(destFile);
       },
       Error,
-      "Please specify if this symlink is absolute or relative. Otherwise, provide the target text.",
+      "Please specify if this symlink is absolute or relative. Otherwise provide the target text.",
     );
   });
 });

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -256,7 +256,7 @@ Deno.test("createSymlinkTo", async () => {
         await symlinkFile.createSymlinkTo(destFile);
       },
       Error,
-      'Missing a `{ kind: "absolute" | "relative" }` property.',
+      "Please specify if this symlink is absolute or relative. Otherwise, provide the target text.",
     );
   });
 });
@@ -295,7 +295,7 @@ Deno.test("createSymlinkToSync", async () => {
         symlinkFile.createSymlinkToSync(destFile);
       },
       Error,
-      'Missing a `{ kind: "absolute" | "relative" }` property.',
+      "Please specify if this symlink is absolute or relative. Otherwise, provide the target text.",
     );
   });
 });

--- a/src/path.ts
+++ b/src/path.ts
@@ -369,7 +369,7 @@ export class PathRef {
           type: opts?.type,
         };
       } else {
-        throw new Error('Missing a `{ kind: "absolute" | "relative" }` property.');
+        throw new Error("Please specify if this symlink is absolute or relative. Otherwise, provide the target text.");
       }
     }
     const targetPath = ensurePathRef(target).resolve();

--- a/src/path.ts
+++ b/src/path.ts
@@ -369,7 +369,7 @@ export class PathRef {
           type: opts?.type,
         };
       } else {
-        throw new Error("Please specify if this symlink is absolute or relative. Otherwise, provide the target text.");
+        throw new Error("Please specify if this symlink is absolute or relative. Otherwise provide the target text.");
       }
     }
     const targetPath = ensurePathRef(target).resolve();

--- a/src/path.ts
+++ b/src/path.ts
@@ -10,9 +10,12 @@ export interface WalkEntry extends Deno.DirEntry {
   path: PathRef;
 }
 
-export interface SymlinkOptions extends Partial<Deno.SymlinkOptions> {
+export interface PathSymlinkOptions {
   /** Creates the symlink as absolute or relative. */
-  kind?: "absolute" | "relative";
+  kind: "absolute" | "relative";
+}
+
+export interface SymlinkOptions extends Partial<Deno.SymlinkOptions>, Partial<PathSymlinkOptions> {
 }
 
 /**
@@ -318,9 +321,19 @@ export class PathRef {
   }
 
   /**
-   * Creates a symlink at the provided path to the provided target returning the target path.
-   * @target - The target text or path of the target.
+   * Creates a symlink to the provided target path.
    */
+  async createSymlinkTo(
+    targetPath: URL | PathRef,
+    opts: Partial<Deno.SymlinkOptions> & PathSymlinkOptions,
+  ): Promise<void>;
+  /**
+   * Creates a symlink at the provided path with the provided target text.
+   */
+  async createSymlinkTo(
+    target: string,
+    opts?: SymlinkOptions,
+  ): Promise<void>;
   async createSymlinkTo(
     target: string | URL | PathRef,
     opts?: SymlinkOptions,
@@ -329,21 +342,35 @@ export class PathRef {
   }
 
   /**
-   * Synchronously creates a symlink at the provided path to the provided target returning the target path.
-   * @target - The target text or path of the target.
+   * Synchronously creates a symlink to the provided target path.
    */
+  createSymlinkToSync(
+    targetPath: URL | PathRef,
+    opts: Partial<Deno.SymlinkOptions> & PathSymlinkOptions,
+  ): void;
+  /**
+   * Synchronously creates a symlink at the provided path with the provided target text.
+   */
+  createSymlinkToSync(
+    target: string,
+    opts?: SymlinkOptions,
+  ): void;
   createSymlinkToSync(target: string | URL | PathRef, opts?: SymlinkOptions): void {
     createSymlinkSync(this.#resolveCreateSymlinkOpts(target, opts));
   }
 
   #resolveCreateSymlinkOpts(target: string | URL | PathRef, opts: SymlinkOptions | undefined): CreateSymlinkOpts {
-    if (opts?.kind == null && typeof target === "string") {
-      return {
-        fromPath: this.resolve(),
-        targetPath: ensurePathRef(target),
-        text: target,
-        type: opts?.type,
-      };
+    if (opts?.kind == null) {
+      if (typeof target === "string") {
+        return {
+          fromPath: this.resolve(),
+          targetPath: ensurePathRef(target),
+          text: target,
+          type: opts?.type,
+        };
+      } else {
+        throw new Error('Missing a `{ kind: "absolute" | "relative" }` property.');
+      }
     }
     const targetPath = ensurePathRef(target).resolve();
     if (opts?.kind === "relative") {


### PR DESCRIPTION
I'm not sure what the right choice is here, so I'm changing it to be explicit for the time being.