### PR TITLE
feat: allow passing a `PathRef` in when creating a `PathRef`

### DIFF
--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -5,7 +5,9 @@ import { path as stdPath } from "./deps.ts";
 Deno.test("create from path ref", () => {
   const path = createPathRef("src");
   const path2 = createPathRef(path);
+  const path3 = new PathRef(path);
   assertEquals(path, path2);
+  assertEquals(path.toString(), path3.toString());
 });
 
 Deno.test("custom inspect", () => {

--- a/src/path.ts
+++ b/src/path.ts
@@ -39,9 +39,11 @@ export class PathRef {
    */
   private static instanceofSymbol = Symbol.for("dax.PathRef");
 
-  constructor(path: string | URL | ImportMeta) {
+  constructor(path: string | URL | ImportMeta | PathRef) {
     if (path instanceof URL) {
       this.#path = stdPath.fromFileUrl(path);
+    } else if (path instanceof PathRef) {
+      this.#path = path.toString();
     } else if (typeof path === "string") {
       if (path.startsWith("file://")) {
         this.#path = stdPath.fromFileUrl(path);


### PR DESCRIPTION
Makes things slightly easier to work with.