### PR TITLE
refactor: PathRef - prefix read methods with `read` for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,14 +496,14 @@ srcDir.isAbsolute(); // true
 // join to get other paths and do actions on them
 const textFile = srcDir.join("subDir").join("file.txt");
 textFile.writeTextSync("some text");
-console.log(textFile.textSync()); // "some text"
+console.log(textFile.readTextSync()); // "some text"
 
 const jsonFile = srcDir.join("otherDir", "file.json");
 console.log(jsonFile.parentOrThrow()); // path for otherDir
 jsonFile.writeJsonSync({
   someValue: 5,
 });
-console.log(jsonFile.jsonSync().someValue); // 5
+console.log(jsonFile.readJsonSync().someValue); // 5
 ```
 
 It also works to provide these paths to commands:

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -427,17 +427,17 @@ Deno.test("readMaybeJson", async () => {
     file.writeJsonSync({ test: 123 });
     let data = file.readMaybeJsonSync();
     assertEquals(data, { test: 123 });
-    data = await file.maybeJson();
+    data = await file.readMaybeJson();
     assertEquals(data, { test: 123 });
     const nonExistent = createPathRef("not-exists");
     data = nonExistent.readMaybeJsonSync();
     assertEquals(data, undefined);
-    data = await nonExistent.maybeJson();
+    data = await nonExistent.readMaybeJson();
     assertEquals(data, undefined);
 
     file.writeTextSync("1 23 532lkjladf asd");
     assertThrows(() => file.readMaybeJsonSync(), Error, "Failed parsing JSON in 'file.json'.");
-    await assertRejects(() => file.maybeJson(), Error, "Failed parsing JSON in 'file.json'.");
+    await assertRejects(() => file.readMaybeJson(), Error, "Failed parsing JSON in 'file.json'.");
   });
 });
 

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -360,83 +360,83 @@ Deno.test("expandGlob", async () => {
   });
 });
 
-Deno.test("bytes", async () => {
+Deno.test("readBytes", async () => {
   await withTempDir(async () => {
     const file = createPathRef("file.txt");
     const bytes = new TextEncoder().encode("asdf");
     file.writeSync(bytes);
-    assertEquals(file.bytesSync(), bytes);
-    assertEquals(await file.bytes(), bytes);
+    assertEquals(file.readBytesSync(), bytes);
+    assertEquals(await file.readBytes(), bytes);
     const nonExistent = createPathRef("not-exists");
-    assertThrows(() => nonExistent.bytesSync());
-    await assertRejects(() => nonExistent.bytes());
+    assertThrows(() => nonExistent.readBytesSync());
+    await assertRejects(() => nonExistent.readBytes());
   });
 });
 
-Deno.test("maybeBytes", async () => {
+Deno.test("readMaybeBytes", async () => {
   await withTempDir(async () => {
     const file = createPathRef("file.txt");
     const bytes = new TextEncoder().encode("asdf");
     await file.write(bytes);
-    assertEquals(file.maybeBytesSync(), bytes);
-    assertEquals(await file.maybeBytes(), bytes);
+    assertEquals(file.readMaybeBytesSync(), bytes);
+    assertEquals(await file.readMaybeBytes(), bytes);
     const nonExistent = createPathRef("not-exists");
-    assertEquals(await nonExistent.maybeText(), undefined);
-    assertEquals(nonExistent.maybeTextSync(), undefined);
+    assertEquals(await nonExistent.readMaybeText(), undefined);
+    assertEquals(nonExistent.readMaybeTextSync(), undefined);
   });
 });
 
-Deno.test("text", async () => {
+Deno.test("readText", async () => {
   await withTempDir(async () => {
     const file = createPathRef("file.txt");
     file.writeTextSync("asdf");
-    assertEquals(file.maybeTextSync(), "asdf");
-    assertEquals(await file.maybeText(), "asdf");
+    assertEquals(file.readMaybeTextSync(), "asdf");
+    assertEquals(await file.readMaybeText(), "asdf");
     const nonExistent = createPathRef("not-exists");
-    assertThrows(() => nonExistent.textSync());
-    await assertRejects(() => nonExistent.text());
+    assertThrows(() => nonExistent.readTextSync());
+    await assertRejects(() => nonExistent.readText());
   });
 });
 
-Deno.test("maybeText", async () => {
+Deno.test("readMaybeText", async () => {
   await withTempDir(async () => {
     const file = createPathRef("file.txt");
     file.writeTextSync("asdf");
-    assertEquals(file.maybeTextSync(), "asdf");
-    assertEquals(await file.maybeText(), "asdf");
+    assertEquals(file.readMaybeTextSync(), "asdf");
+    assertEquals(await file.readMaybeText(), "asdf");
     const nonExistent = createPathRef("not-exists");
-    assertEquals(await nonExistent.maybeText(), undefined);
-    assertEquals(nonExistent.maybeTextSync(), undefined);
+    assertEquals(await nonExistent.readMaybeText(), undefined);
+    assertEquals(nonExistent.readMaybeTextSync(), undefined);
   });
 });
 
-Deno.test("json", async () => {
+Deno.test("readJson", async () => {
   await withTempDir(async () => {
     const file = createPathRef("file.txt");
     file.writeJsonSync({ test: 123 });
-    let data = file.jsonSync();
+    let data = file.readJsonSync();
     assertEquals(data, { test: 123 });
-    data = await file.json();
+    data = await file.readJson();
     assertEquals(data, { test: 123 });
   });
 });
 
-Deno.test("maybeJson", async () => {
+Deno.test("readMaybeJson", async () => {
   await withTempDir(async () => {
     const file = createPathRef("file.json");
     file.writeJsonSync({ test: 123 });
-    let data = file.maybeJsonSync();
+    let data = file.readMaybeJsonSync();
     assertEquals(data, { test: 123 });
     data = await file.maybeJson();
     assertEquals(data, { test: 123 });
     const nonExistent = createPathRef("not-exists");
-    data = nonExistent.maybeJsonSync();
+    data = nonExistent.readMaybeJsonSync();
     assertEquals(data, undefined);
     data = await nonExistent.maybeJson();
     assertEquals(data, undefined);
 
     file.writeTextSync("1 23 532lkjladf asd");
-    assertThrows(() => file.maybeJsonSync(), Error, "Failed parsing JSON in 'file.json'.");
+    assertThrows(() => file.readMaybeJsonSync(), Error, "Failed parsing JSON in 'file.json'.");
     await assertRejects(() => file.maybeJson(), Error, "Failed parsing JSON in 'file.json'.");
   });
 });
@@ -450,16 +450,16 @@ Deno.test("write", async () => {
     const file4 = dir.join("subDir4/file.txt");
 
     await file1.writeText("test");
-    assertEquals(file1.textSync(), "test");
+    assertEquals(file1.readTextSync(), "test");
 
     file2.writeTextSync("test");
-    assertEquals(file2.textSync(), "test");
+    assertEquals(file2.readTextSync(), "test");
 
     await file3.write(new TextEncoder().encode("test"));
-    assertEquals(file3.textSync(), "test");
+    assertEquals(file3.readTextSync(), "test");
 
     file4.writeSync(new TextEncoder().encode("test"));
-    assertEquals(file4.textSync(), "test");
+    assertEquals(file4.readTextSync(), "test");
 
     // writing on top of a file it should return the original not found error
     const fileOnFile = file1.join("fileOnFile");
@@ -476,22 +476,22 @@ Deno.test("writeJson", async () => {
     await path.writeJson({
       prop: "test",
     });
-    assertEquals(path.textSync(), `{"prop":"test"}\n`);
+    assertEquals(path.readTextSync(), `{"prop":"test"}\n`);
     await path.writeJson({
       prop: 1,
     });
     // should truncate
-    assertEquals(path.textSync(), `{"prop":1}\n`);
+    assertEquals(path.readTextSync(), `{"prop":1}\n`);
 
     path.writeJsonSync({
       asdf: "test",
     });
-    assertEquals(path.textSync(), `{"asdf":"test"}\n`);
+    assertEquals(path.readTextSync(), `{"asdf":"test"}\n`);
     path.writeJsonSync({
       asdf: 1,
     });
     // should truncate
-    assertEquals(path.textSync(), `{"asdf":1}\n`);
+    assertEquals(path.readTextSync(), `{"asdf":1}\n`);
   });
 });
 
@@ -501,22 +501,22 @@ Deno.test("writeJsonPretty", async () => {
     await path.writeJsonPretty({
       prop: "test",
     });
-    assertEquals(path.textSync(), `{\n  "prop": "test"\n}\n`);
+    assertEquals(path.readTextSync(), `{\n  "prop": "test"\n}\n`);
     await path.writeJsonPretty({
       prop: 1,
     });
     // should truncate
-    assertEquals(path.textSync(), `{\n  "prop": 1\n}\n`);
+    assertEquals(path.readTextSync(), `{\n  "prop": 1\n}\n`);
 
     path.writeJsonPrettySync({
       asdf: "test",
     });
-    assertEquals(path.textSync(), `{\n  "asdf": "test"\n}\n`);
+    assertEquals(path.readTextSync(), `{\n  "asdf": "test"\n}\n`);
     path.writeJsonPrettySync({
       asdf: 1,
     });
     // should truncate
-    assertEquals(path.textSync(), `{\n  "asdf": 1\n}\n`);
+    assertEquals(path.readTextSync(), `{\n  "asdf": 1\n}\n`);
   });
 });
 
@@ -562,7 +562,7 @@ Deno.test("open", async () => {
     file = path.openSync({ write: true, append: true });
     await file.writeBytes(new TextEncoder().encode("3"));
     file.close();
-    assertEquals(path.textSync(), "12xt3");
+    assertEquals(path.readTextSync(), "12xt3");
   });
 });
 
@@ -583,10 +583,10 @@ Deno.test("copyFile", async () => {
     const newPath = await path.copyFile("other.txt");
     assert(path.existsSync());
     assert(newPath.existsSync());
-    assertEquals(newPath.textSync(), "text");
+    assertEquals(newPath.readTextSync(), "text");
     const newPath2 = path.copyFileSync("other2.txt");
     assert(newPath2.existsSync());
-    assertEquals(newPath2.textSync(), "text");
+    assertEquals(newPath2.readTextSync(), "text");
   });
 });
 
@@ -610,7 +610,7 @@ Deno.test("pipeTo", async () => {
     const otherFilePath = textFile.parentOrThrow().join("other.txt");
     const otherFile = otherFilePath.openSync({ write: true, create: true });
     await textFile.pipeTo(otherFile.writable);
-    assertEquals(otherFilePath.textSync(), largeText);
+    assertEquals(otherFilePath.readTextSync(), largeText);
   });
 });
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -441,58 +441,58 @@ export class PathRef {
   }
 
   /** Reads the bytes from the file. */
-  bytes(options?: Deno.ReadFileOptions): Promise<Uint8Array> {
+  readBytes(options?: Deno.ReadFileOptions): Promise<Uint8Array> {
     return Deno.readFile(this.#path, options);
   }
 
   /** Synchronously reads the bytes from the file. */
-  bytesSync(): Uint8Array {
+  readBytesSync(): Uint8Array {
     return Deno.readFileSync(this.#path);
   }
 
-  /** Calls `.bytes()`, but returns undefined if the path doesn't exist. */
-  maybeBytes(options?: Deno.ReadFileOptions): Promise<Uint8Array | undefined> {
-    return notFoundToUndefined(() => this.bytes(options));
+  /** Calls `.readBytes()`, but returns undefined if the path doesn't exist. */
+  readMaybeBytes(options?: Deno.ReadFileOptions): Promise<Uint8Array | undefined> {
+    return notFoundToUndefined(() => this.readBytes(options));
   }
 
-  /** Calls `.bytesSync()`, but returns undefined if the path doesn't exist. */
-  maybeBytesSync(): Uint8Array | undefined {
-    return notFoundToUndefinedSync(() => this.bytesSync());
+  /** Calls `.readBytesSync()`, but returns undefined if the path doesn't exist. */
+  readMaybeBytesSync(): Uint8Array | undefined {
+    return notFoundToUndefinedSync(() => this.readBytesSync());
   }
 
   /** Reads the text from the file. */
-  text(options?: Deno.ReadFileOptions): Promise<string> {
+  readText(options?: Deno.ReadFileOptions): Promise<string> {
     return Deno.readTextFile(this.#path, options);
   }
 
   /** Synchronously reads the text from the file. */
-  textSync(): string {
+  readTextSync(): string {
     return Deno.readTextFileSync(this.#path);
   }
 
-  /** Calls `.text()`, but returns undefined when the path doesn't exist.
+  /** Calls `.readText()`, but returns undefined when the path doesn't exist.
    * @remarks This still errors for other kinds of errors reading a file.
    */
-  maybeText(options?: Deno.ReadFileOptions): Promise<string | undefined> {
-    return notFoundToUndefined(() => this.text(options));
+  readMaybeText(options?: Deno.ReadFileOptions): Promise<string | undefined> {
+    return notFoundToUndefined(() => this.readText(options));
   }
 
-  /** Calls `.textSync()`, but returns undefined when the path doesn't exist.
+  /** Calls `.readTextSync()`, but returns undefined when the path doesn't exist.
    * @remarks This still errors for other kinds of errors reading a file.
    */
-  maybeTextSync(): string | undefined {
-    return notFoundToUndefinedSync(() => this.textSync());
+  readMaybeTextSync(): string | undefined {
+    return notFoundToUndefinedSync(() => this.readTextSync());
   }
 
   /** Reads and parses the file as JSON, throwing if it doesn't exist or is not valid JSON. */
-  async json<T>(options?: Deno.ReadFileOptions): Promise<T> {
-    return this.#parseJson<T>(await this.text(options));
+  async readJson<T>(options?: Deno.ReadFileOptions): Promise<T> {
+    return this.#parseJson<T>(await this.readText(options));
   }
 
   /** Synchronously reads and parses the file as JSON, throwing if it doesn't
    * exist or is not valid JSON. */
-  jsonSync<T>(): T {
-    return this.#parseJson<T>(this.textSync());
+  readJsonSync<T>(): T {
+    return this.#parseJson<T>(this.readTextSync());
   }
 
   #parseJson<T>(text: string) {
@@ -506,19 +506,19 @@ export class PathRef {
   }
 
   /**
-   * Calls `.json()`, but returns undefined if the file doesn't exist.
+   * Calls `.readJson()`, but returns undefined if the file doesn't exist.
    * @remarks This method will still throw if the file cannot be parsed as JSON.
    */
   maybeJson<T>(options?: Deno.ReadFileOptions): Promise<T | undefined> {
-    return notFoundToUndefined(() => this.json<T>(options));
+    return notFoundToUndefined(() => this.readJson<T>(options));
   }
 
   /**
-   * Calls `.jsonSync()`, but returns undefined if the file doesn't exist.
+   * Calls `.readJsonSync()`, but returns undefined if the file doesn't exist.
    * @remarks This method will still throw if the file cannot be parsed as JSON.
    */
-  maybeJsonSync<T>(): T | undefined {
-    return notFoundToUndefinedSync(() => this.jsonSync<T>());
+  readMaybeJsonSync<T>(): T | undefined {
+    return notFoundToUndefinedSync(() => this.readJsonSync<T>());
   }
 
   /** Writes out the provided bytes to the file. */

--- a/src/path.ts
+++ b/src/path.ts
@@ -509,7 +509,7 @@ export class PathRef {
    * Calls `.readJson()`, but returns undefined if the file doesn't exist.
    * @remarks This method will still throw if the file cannot be parsed as JSON.
    */
-  maybeJson<T>(options?: Deno.ReadFileOptions): Promise<T | undefined> {
+  readMaybeJson<T>(options?: Deno.ReadFileOptions): Promise<T | undefined> {
     return notFoundToUndefined(() => this.readJson<T>(options));
   }
 

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -116,7 +116,7 @@ Deno.test("$.request", (t) => {
             .url(new URL("/text-file", serverUrl))
             .showProgress()
             .pipeToPath(testFilePath);
-          assertEquals(downloadedFilePath.textSync(), "text".repeat(1000));
+          assertEquals(downloadedFilePath.readTextSync(), "text".repeat(1000));
           assertEquals(downloadedFilePath.toString(), path.resolve(testFilePath));
         }
         {
@@ -126,7 +126,7 @@ Deno.test("$.request", (t) => {
             .url(new URL("/text-file", serverUrl))
             .showProgress()
             .pipeToPath();
-          assertEquals(downloadedFilePath.textSync(), "text".repeat(1000));
+          assertEquals(downloadedFilePath.readTextSync(), "text".repeat(1000));
           assertEquals(downloadedFilePath.toString(), path.resolve("text-file"));
         }
         {
@@ -156,7 +156,7 @@ Deno.test("$.request", (t) => {
             .url(new URL("/text-file", serverUrl))
             .showProgress()
             .pipeToPath(tempDir);
-          assertEquals(downloadedFilePath.textSync(), "text".repeat(1000));
+          assertEquals(downloadedFilePath.readTextSync(), "text".repeat(1000));
           assertEquals(downloadedFilePath.toString(), path.join(tempDir, "text-file"));
         }
       } finally {


### PR DESCRIPTION
I started actually using this and found myself consistently typing `read` before these, getting no results, and being confused.