### PR TITLE
feat: PathRef.prototype.copyFileToDir

### DIFF
--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -677,6 +677,24 @@ Deno.test("copyFile", async () => {
   });
 });
 
+Deno.test("copyFileToDir", async () => {
+  await withTempDir(async () => {
+    const path = createPathRef("file.txt")
+      .writeTextSync("text");
+    const dir = createPathRef("dir").mkdirSync();
+    const newPath = await path.copyFileToDir(dir);
+    assert(path.existsSync());
+    assert(newPath.existsSync());
+    assertEquals(dir.join("file.txt").toString(), newPath.toString());
+    assertEquals(newPath.readTextSync(), "text");
+    const dir2 = createPathRef("dir2").mkdirSync();
+    const newPath2 = path.copyFileToDir(dir2);
+    assert(newPath2.existsSync());
+    assertEquals(newPath2.readTextSync(), "text");
+    assertEquals(newPath2.toString(), dir2.join("file.txt").toString());
+  });
+});
+
 Deno.test("rename", async () => {
   await withTempDir(async () => {
     const path = createPathRef("file.txt").writeTextSync("");

--- a/src/path.ts
+++ b/src/path.ts
@@ -802,8 +802,8 @@ export class PathRef {
   }
 
   /**
-   * Copies the file returning a promise that resolves to
-   * the destination path.
+   * Copies the file to the specified destination path.
+   * @returns The destination file path.
    */
   copyFile(destinationPath: string | URL | PathRef): Promise<PathRef> {
     const pathRef = ensurePathRef(destinationPath);
@@ -812,13 +812,33 @@ export class PathRef {
   }
 
   /**
-   * Copies the file returning a promise that resolves to
-   * the destination path synchronously.
+   * Copies the file to the destination path synchronously.
+   * @returns The destination file path.
    */
   copyFileSync(destinationPath: string | URL | PathRef): PathRef {
     const pathRef = ensurePathRef(destinationPath);
     Deno.copyFileSync(this.#path, pathRef.#path);
     return pathRef;
+  }
+
+  /**
+   * Copies the file to the specified directory.
+   * @returns The destination file path.
+   */
+  copyFileToDir(destinationDirPath: string | URL | PathRef): PathRef {
+    const destinationPath = ensurePathRef(destinationDirPath)
+      .join(this.basename());
+    return this.copyFileSync(destinationPath);
+  }
+
+  /**
+   * Copies the file to the specified directory synchronously.
+   * @returns The destination file path.
+   */
+  copyFileToDirSync(destinationDirPath: string | URL | PathRef): PathRef {
+    const destinationPath = ensurePathRef(destinationDirPath)
+      .join(this.basename());
+    return this.copyFileSync(destinationPath);
   }
 
   /**


### PR DESCRIPTION
I found myself writing stuff like:

```ts
currentDir.join("bin.js").copyFileSync(dprintDir.join("bin.js"));
currentDir.join("install_api.js").copyFileSync(dprintDir.join("install_api.js"));
currentDir.join("install.js").copyFileSync(dprintDir.join("install.js"));
```

This could be simplified to:

```ts
currentDir.join("bin.js").copyFileToDirSync(dprintDir);
currentDir.join("install_api.js").copyFileToDirSync(dprintDir);
currentDir.join("install.js").copyFileToDirSync(dprintDir);
```