### PR TITLE
fix: pass clearEnv: true when calling child process

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -585,6 +585,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
       args: commandArgs.slice(1),
       cwd,
       env: context.getEnvVars(),
+      clearEnv: true,
       ...pipeStringVals,
     }).spawn();
   } catch (err) {


### PR DESCRIPTION
I believe this is technically more correct.