### PR TITLE
fix: surface command exit code on kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ await $`echo ${text}`; // will output `> echo example` before running the comman
 
 ### Timeout a command
 
-This will exit with code 124.
+This will exit with code 124 after 1 second.
 
 ```ts
 // timeout a command after a specified time

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -638,8 +638,6 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
         code: 1,
         kind: "exit",
       };
-    } else if (context.signal.aborted) {
-      return getAbortedResult();
     } else {
       return resultFromCode(status.code);
     }


### PR DESCRIPTION
It shouldn't be surfacing the abort exit code, unless a command attempts to run after failure. This will allow people to return and handle different exit codes based on what signal is sent to the command.

I *think* on timeout it should always surface the abort exit code on failure though and not the command's exit code in order for people to easily be able to test for a timeout having occurred.