### PR TITLE
feat: PathRef improvements and drop deno_std fs & path re-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,20 +616,6 @@ This line will appear without any indentation.
 Empty lines (like the one above) will not affect the common indentation.
 ```
 
-Re-export of deno_std's path (though you might want to just use the path API described above):
-
-```ts
-$.path.basename("./deno/std/path/mod.ts"); // mod.ts
-```
-
-Re-export of deno_std's fs:
-
-```ts
-for await (const file of $.fs.expandGlob("**/*.ts")) {
-  console.log(file);
-}
-```
-
 Remove ansi escape sequences from a string:
 
 ```ts

--- a/mod.ts
+++ b/mod.ts
@@ -25,7 +25,7 @@ import {
   select,
   SelectOptions,
 } from "./src/console/mod.ts";
-import { colors, fs, outdent, path as stdPath, which, whichSync } from "./src/deps.ts";
+import { colors, outdent, which, whichSync } from "./src/deps.ts";
 import { wasmInstance } from "./src/lib/mod.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { createPathRef, PathRef } from "./src/path.ts";
@@ -217,15 +217,12 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    * will be resolved by the shell of the current `$` or false otherwise.
    */
   commandExistsSync(commandName: string): boolean;
-  /** Re-export of deno_std's `fs` module. */
-  fs: typeof fs;
   /** Helper function for creating path references, which provide an easier way for
-   * working with paths, directories, and files on the file system. Also, a re-export
-   * of deno_std's `path` module as properties on this object.
+   * working with paths, directories, and files on the file system.
    *
    * The function creates a new `PathRef` from a path or URL string, file URL, or for the current module.
    */
-  path: typeof createPathRef & typeof stdPath;
+  path: typeof createPathRef;
   /**
    * Logs with potential indentation (`$.logIndent`)
    * and output of commands or request responses.
@@ -539,8 +536,7 @@ function buildInitial$State<TExtras extends ExtrasObject>(
 }
 
 const helperObject = {
-  fs,
-  path: Object.assign(createPathRef, stdPath),
+  path: createPathRef,
   cd,
   escapeArg,
   stripAnsi(text: string) {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -8,3 +8,11 @@ export { readerFromStreamReader } from "https://deno.land/std@0.182.0/streams/re
 export { writeAll, writeAllSync } from "https://deno.land/std@0.182.0/streams/write_all.ts";
 export { outdent } from "https://deno.land/x/outdent@v0.8.0/src/index.ts";
 export { RealEnvironment as DenoWhichRealEnvironment, which, whichSync } from "https://deno.land/x/which@0.3.0/mod.ts";
+
+export { emptyDir, emptyDirSync } from "https://deno.land/std@0.182.0/fs/empty_dir.ts";
+export { ensureDir, ensureDirSync } from "https://deno.land/std@0.182.0/fs/ensure_dir.ts";
+export { ensureFile, ensureFileSync } from "https://deno.land/std@0.182.0/fs/ensure_file.ts";
+export { expandGlob, type ExpandGlobOptions, expandGlobSync } from "https://deno.land/std@0.182.0/fs/expand_glob.ts";
+export { move, moveSync } from "https://deno.land/std@0.182.0/fs/move.ts";
+export { copy, copySync } from "https://deno.land/std@0.182.0/fs/copy.ts";
+export { walk, type WalkEntry, WalkError, type WalkOptions, walkSync } from "https://deno.land/std@0.182.0/fs/walk.ts";

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,4 +1,21 @@
-import { fs, path as stdPath, writeAll, writeAllSync } from "./deps.ts";
+import {
+  emptyDir,
+  emptyDirSync,
+  ensureDir,
+  ensureDirSync,
+  ensureFile,
+  ensureFileSync,
+  expandGlob,
+  expandGlobSync,
+  path as stdPath,
+  walk,
+  walkSync,
+  writeAll,
+  writeAllSync,
+} from "./deps.ts";
+
+export type ExpandGlobOptions = import("./deps.ts").ExpandGlobOptions;
+export type WalkOptions = import("./deps.ts").WalkOptions;
 
 const PERIOD_CHAR_CODE = ".".charCodeAt(0);
 
@@ -215,6 +232,73 @@ export class PathRef {
     }
   }
 
+  *components(): Generator<string> {
+    const path = this.normalize();
+    let last_index = 0;
+    while (true) {
+      // todo: separate `/` on windows? See what rust does
+      const index = path.#path.indexOf(stdPath.SEP, last_index);
+      if (index < 0) {
+        const part = path.#path.substring(last_index);
+        if (part.length > 0) {
+          yield part;
+        }
+        return;
+      }
+      yield path.#path.substring(last_index, index);
+      last_index = index + 1;
+    }
+  }
+
+  *rcomponents(): Generator<string> {
+    const path = this.normalize();
+    let last_index = undefined;
+    while (true) {
+      // todo: separate `/` on windows? See what rust does
+      const index = path.#path.lastIndexOf(stdPath.SEP, last_index == null ? undefined : last_index - 1);
+      if (index < 0) {
+        const part = path.#path.substring(0, last_index);
+        if (part.length > 0) {
+          yield part;
+        }
+        return;
+      }
+      const part = path.#path.substring(index + 1, last_index);
+      if (last_index != null || part.length > 0) {
+        yield part;
+      }
+      last_index = index;
+    }
+  }
+
+  startsWith(path: PathRef | URL | string): boolean {
+    const startsWithComponents = ensurePathRef(path).components();
+    for (const component of this.components()) {
+      const next = startsWithComponents.next();
+      if (next.done) {
+        return true;
+      }
+      if (next.value !== component) {
+        return false;
+      }
+    }
+    return startsWithComponents.next().done ?? true;
+  }
+
+  endsWith(path: PathRef | URL | string): boolean {
+    const endsWithComponents = ensurePathRef(path).rcomponents();
+    for (const component of this.rcomponents()) {
+      const next = endsWithComponents.next();
+      if (next.done) {
+        return true;
+      }
+      if (next.value !== component) {
+        return false;
+      }
+    }
+    return endsWithComponents.next().done ?? true;
+  }
+
   /** Gets the parent directory or returns undefined if the parent is the root directory. */
   parent(): PathRef | undefined {
     const resolvedPath = this.resolve();
@@ -289,9 +373,9 @@ export class PathRef {
   /** Expands the glob using the current path as the root. */
   async *expandGlob(
     glob: string | URL,
-    options?: Omit<fs.ExpandGlobOptions, "root">,
+    options?: Omit<ExpandGlobOptions, "root">,
   ): AsyncGenerator<WalkEntry, void, unknown> {
-    const entries = fs.expandGlob(glob, {
+    const entries = expandGlob(glob, {
       root: this.resolve().toString(),
       ...options,
     });
@@ -303,9 +387,9 @@ export class PathRef {
   /** Synchronously expands the glob using the current path as the root. */
   *expandGlobSync(
     glob: string | URL,
-    options?: Omit<fs.ExpandGlobOptions, "root">,
+    options?: Omit<ExpandGlobOptions, "root">,
   ): Generator<WalkEntry, void, unknown> {
-    const entries = fs.expandGlobSync(glob, {
+    const entries = expandGlobSync(glob, {
       root: this.resolve().toString(),
       ...options,
     });
@@ -316,23 +400,23 @@ export class PathRef {
 
   /** Walks the file tree rooted at the current path, yielding each file or
    * directory in the tree filtered according to the given options. */
-  async *walk(options?: fs.WalkOptions): AsyncIterableIterator<WalkEntry> {
+  async *walk(options?: WalkOptions): AsyncIterableIterator<WalkEntry> {
     // Resolve the path before walking so that these paths always point to
     // absolute paths in the case that someone changes the cwd after walking.
-    for await (const entry of fs.walk(this.resolve().toString(), options)) {
+    for await (const entry of walk(this.resolve().toString(), options)) {
       yield this.#stdWalkEntryToDax(entry);
     }
   }
 
   /** Synchronously walks the file tree rooted at the current path, yielding each
    * file or directory in the tree filtered according to the given options. */
-  *walkSync(options?: fs.WalkOptions): Iterable<WalkEntry> {
-    for (const entry of fs.walkSync(this.resolve().toString(), options)) {
+  *walkSync(options?: WalkOptions): Iterable<WalkEntry> {
+    for (const entry of walkSync(this.resolve().toString(), options)) {
       yield this.#stdWalkEntryToDax(entry);
     }
   }
 
-  #stdWalkEntryToDax(entry: fs.WalkEntry): WalkEntry {
+  #stdWalkEntryToDax(entry: import("./deps.ts").WalkEntry): WalkEntry {
     return {
       ...entry,
       path: new PathRef(entry.path),
@@ -789,13 +873,51 @@ export class PathRef {
    * The directory itself is not deleted.
    */
   async emptyDir(): Promise<this> {
-    await fs.emptyDir(this.toString());
+    await emptyDir(this.toString());
     return this;
   }
 
   /** Synchronous version of `emptyDir()` */
   emptyDirSync(): this {
-    fs.emptyDirSync(this.toString());
+    emptyDirSync(this.toString());
+    return this;
+  }
+
+  /** Ensures that the directory exists.
+   * If the directory structure does not exist, it is created. Like mkdir -p.
+   */
+  async ensureDir(): Promise<this> {
+    await ensureDir(this.toString());
+    return this;
+  }
+
+  /** Synchronously ensures that the directory exists.
+   * If the directory structure does not exist, it is created. Like mkdir -p.
+   */
+  ensureDirSync(): this {
+    ensureDirSync(this.toString());
+    return this;
+  }
+
+  /**
+   * Ensures that the file exists.
+   * If the file that is requested to be created is in directories that do
+   * not exist these directories are created. If the file already exists,
+   * it is NOTMODIFIED.
+   */
+  async ensureFile(): Promise<this> {
+    await ensureFile(this.toString());
+    return this;
+  }
+
+  /**
+   * Synchronously ensures that the file exists.
+   * If the file that is requested to be created is in directories that do
+   * not exist these directories are created. If the file already exists,
+   * it is NOTMODIFIED.
+   */
+  ensureFileSync(): this {
+    ensureFileSync(this.toString());
     return this;
   }
 


### PR DESCRIPTION
PathRef:

- `startsWith(path: PathRef | URL | string): boolean`
- `endsWith(path: PathRef | URL | string): boolean`
- `components(): Generator<string>`
- `ensureDir(): Promise<this>`
- `ensureDirSync(): this`
- `ensureFile(): Promise<this>`
- `ensureFileSync(): this`

Removes `$.fs` and `$.path` re-exports of deno_std.

Closes #126
Closes #106

Part of #105