### PR TITLE
refactor: rename more synchronous path methods to have `Sync` suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,10 +506,10 @@ The path API offers an immutable [`PathRef`](https://deno.land/x/dax/src/path.ts
 // create a `PathRef`
 let srcDir = $.path("src");
 // get information about the path
-srcDir.isDir(); // false
+srcDir.isDirSync(); // false
 // do actions on it
-srcDir.mkdir();
-srcDir.isDir(); // true
+await srcDir.mkdir();
+srcDir.isDirSync(); // true
 
 srcDir.isRelative(); // true
 srcDir = srcDir.resolve(); // resolve the path to be absolute

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1236,7 +1236,7 @@ Deno.test("copy test", async () => {
     newFile.writeTextSync("test");
     await $`cp ${newFile} ${destDir}`;
 
-    assert(destDir.isDir());
+    assert(destDir.isDirSync());
     assert(newFile.existsSync());
     assert(destDir.join("new.txt").existsSync());
 
@@ -1302,7 +1302,7 @@ Deno.test("move test", async () => {
     const newFile = dir.join("new.txt");
     newFile.writeTextSync("test");
     await $`mv ${newFile} ${destDir}`;
-    assert(destDir.isDir());
+    assert(destDir.isDirSync());
     assert(!newFile.existsSync());
     assert(destDir.join("new.txt").existsSync());
 

--- a/src/path.test.ts
+++ b/src/path.test.ts
@@ -40,15 +40,15 @@ Deno.test("normalize", () => {
 });
 
 Deno.test("isDir", () => {
-  assert(createPathRef("src").isDir());
-  assert(!createPathRef("mod.ts").isDir());
-  assert(!createPathRef("nonExistent").isDir());
+  assert(createPathRef("src").isDirSync());
+  assert(!createPathRef("mod.ts").isDirSync());
+  assert(!createPathRef("nonExistent").isDirSync());
 });
 
 Deno.test("isFile", () => {
-  assert(!createPathRef("src").isFile());
-  assert(createPathRef("mod.ts").isFile());
-  assert(!createPathRef("nonExistent").isFile());
+  assert(!createPathRef("src").isFileSync());
+  assert(createPathRef("mod.ts").isFileSync());
+  assert(!createPathRef("nonExistent").isFileSync());
 });
 
 Deno.test("isSymlink", async () => {
@@ -56,8 +56,8 @@ Deno.test("isSymlink", async () => {
     const file = createPathRef("file.txt").writeTextSync("");
     const symlinkFile = createPathRef("test.txt");
     symlinkFile.createSymlinkToSync(file, { kind: "absolute" });
-    assert(symlinkFile.isSymlink());
-    assert(!file.isSymlink());
+    assert(symlinkFile.isSymlinkSync());
+    assert(!file.isSymlinkSync());
   });
 });
 
@@ -243,11 +243,11 @@ Deno.test("mkdir", async () => {
   await withTempDir(async () => {
     const path = createPathRef("dir");
     await path.mkdir();
-    assert(path.isDir());
+    assert(path.isDirSync());
     path.removeSync();
-    assert(!path.isDir());
+    assert(!path.isDirSync());
     path.mkdirSync();
-    assert(path.isDir());
+    assert(path.isDirSync());
     const nestedDir = path.join("subdir", "subsubdir", "sub");
     await assertRejects(() => nestedDir.mkdir({ recursive: false }));
     assertThrows(() => nestedDir.mkdirSync({ recursive: false }));
@@ -271,7 +271,7 @@ Deno.test("createSymlinkTo", async () => {
     const stat = await symlinkFile.stat();
     assertEquals(stat!.isFile, true);
     assertEquals(stat!.isSymlink, false);
-    assert(symlinkFile.isSymlink());
+    assert(symlinkFile.isSymlinkSync());
 
     // invalid
     await assertRejects(
@@ -295,7 +295,7 @@ Deno.test("createSymlinkToSync", async () => {
     const stat = symlinkFile.statSync();
     assertEquals(stat!.isFile, true);
     assertEquals(stat!.isSymlink, false);
-    assert(symlinkFile.isSymlink());
+    assert(symlinkFile.isSymlinkSync());
 
     // path ref absolute
     symlinkFile.removeSync();

--- a/src/path.ts
+++ b/src/path.ts
@@ -114,17 +114,17 @@ export class PathRef {
   }
 
   /** Follows symlinks and gets if this path is a directory. */
-  isDir(): boolean {
+  isDirSync(): boolean {
     return this.statSync()?.isDirectory ?? false;
   }
 
   /** Follows symlinks and gets if this path is a file. */
-  isFile(): boolean {
+  isFileSync(): boolean {
     return this.statSync()?.isFile ?? false;
   }
 
   /** Gets if this path is a symlink. */
-  isSymlink(): boolean {
+  isSymlinkSync(): boolean {
     return this.lstatSync()?.isSymlink ?? false;
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -667,7 +667,7 @@ function resolvePipeToPathParams(
   }
   if (filePath === undefined) {
     filePath = new PathRef(getFileNameFromUrlOrThrow(originalUrl));
-  } else if (filePath.isDir()) {
+  } else if (filePath.isDirSync()) {
     filePath = filePath.join(getFileNameFromUrlOrThrow(originalUrl));
   }
   filePath = filePath.resolve();


### PR DESCRIPTION
This is probably more appropriate and consistent even though it's more verbose.