### PR TITLE
docs: correct `PathRef.prototype.renameSync` docs

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -849,8 +849,7 @@ export class PathRef {
   }
 
   /**
-   * Moves the file or directory returning a promise that resolves to
-   * the renamed path synchronously.
+   * Moves the file or directory returning the renamed path synchronously.
    */
   renameSync(newPath: string | URL | PathRef): PathRef {
     const pathRef = ensurePathRef(newPath);


### PR DESCRIPTION
Spotted when reading the docs: https://deno.land/x/dax@0.34.0/src/path.ts?s=PathRef#method_renameSync_0
