### PR TITLE
feat: allow user to --deny-env

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -853,6 +853,10 @@ export class CommandResult {
 }
 
 function buildEnv(env: Record<string, string | undefined>) {
+  const envPermissions = Deno.permissions.querySync({ name: "env" });
+  if (envPermissions.state == "denied") {
+    return env;
+  }
   const result = Deno.env.toObject();
   for (const [key, value] of Object.entries(env)) {
     if (value == null) {


### PR DESCRIPTION
### What
Allow the user to deny dax from accessing the env, by checking if env has been denied before attempting to read from the env. Assumes

### Why
It's not always necessary for scripts to access the env and dax is exposed to the env unnecessarily. Dax currently doesn't provide a way to turn the need for env off.

Note that if `--deny-env` is not passed, and the env has not been allowed, then this change will still cause the prompt to appear. The only situation this change impacts is when a script has explicitly denied access to the env.