### PR TITLE
feat: allow user to --deny-read for the cwd

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -607,7 +607,7 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
         stderr,
         env: buildEnv(state.env),
         commands: state.commands,
-        cwd: state.cwd ?? Deno.cwd(),
+        cwd: state.cwd ?? getCwd(),
         exportEnv: state.exportEnv,
         signal,
       });
@@ -862,6 +862,17 @@ function buildEnv(env: Record<string, string | undefined>) {
     }
   }
   return result;
+}
+
+function getCwd(): string {
+  const readPermissions = Deno.permissions.querySync({
+    name: "read",
+    path: ".",
+  });
+  if (readPermissions.state == "denied") {
+    return "";
+  }
+  return Deno.cwd();
 }
 
 export function escapeArg(arg: string) {


### PR DESCRIPTION
### What
Allow the user to deny dax from reading the current working directory, by checking if read permission has been denied. 

### Why
It's not always necessary for scripts to access the current working directory.

Note that if `--deny-read=.` is not passed, and reading the path has not been allowed, then this change will still prompt.