### PR TITLE
feat: allow passing writers to `stdout` and `stderr` builder methods

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -47,6 +47,12 @@ Deno.test("should capture stdout when inherited and piped", async () => {
   assertEquals(output.stdout, "5\n");
 });
 
+Deno.test("should not get stdout when set to writer", async () => {
+  const output = await $`echo 5`.stdout(new Buffer());
+  assertEquals(output.code, 0);
+  assertThrows(() => output.stdout, Error, `Stdout was streamed to another source and is no longer available.`);
+});
+
 Deno.test("should not get stderr when inherited only (default)", async () => {
   const output = await $`deno eval 'console.error("should output");'`;
   assertEquals(output.code, 0);
@@ -77,6 +83,16 @@ Deno.test("should capture stderr when inherited and piped", async () => {
   const output = await $`deno eval -q 'console.error(5);'`.stderr("inheritPiped");
   assertEquals(output.code, 0);
   assertEquals(output.stderr, "5\n");
+});
+
+Deno.test("should not get stderr when set to writer", async () => {
+  const output = await $`echo 5`.stderr(new Buffer());
+  assertEquals(output.code, 0);
+  assertThrows(
+    () => output.stderr,
+    Error,
+    `Stderr was not piped (was streamed). Call .stderr(\"piped\") or .stderr(\"inheritPiped\") when building the command.`,
+  );
 });
 
 Deno.test("should get combined stdout and stderr when specified", async () => {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -48,8 +48,10 @@ Deno.test("should capture stdout when inherited and piped", async () => {
 });
 
 Deno.test("should not get stdout when set to writer", async () => {
-  const output = await $`echo 5`.stdout(new Buffer());
+  const buffer = new Buffer();
+  const output = await $`echo 5`.stdout(buffer);
   assertEquals(output.code, 0);
+  assertEquals(new TextDecoder().decode(buffer.bytes()), "5\n");
   assertThrows(() => output.stdout, Error, `Stdout was streamed to another source and is no longer available.`);
 });
 
@@ -86,8 +88,10 @@ Deno.test("should capture stderr when inherited and piped", async () => {
 });
 
 Deno.test("should not get stderr when set to writer", async () => {
-  const output = await $`echo 5`.stderr(new Buffer());
+  const buffer = new Buffer();
+  const output = await $`deno eval 'console.error(5); console.log(1);'`.stderr(buffer);
   assertEquals(output.code, 0);
+  assertEquals(new TextDecoder().decode(buffer.bytes()), "5\n");
   assertThrows(
     () => output.stderr,
     Error,

--- a/src/command.ts
+++ b/src/command.ts
@@ -728,10 +728,9 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
     } else if (buffer instanceof PipedBuffer) {
       buffer.close();
       return buffer.getBuffer() ?? "streamed";
+    } else if (typeof buffer === "object") {
+      return "streamed";
     } else {
-      if (typeof buffer === "object") {
-        return "streamed";
-      }
       return buffer;
     }
   }

--- a/src/command.ts
+++ b/src/command.ts
@@ -397,6 +397,9 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
     });
 
     function getQuietKind(kind: ShellPipeWriterKind): ShellPipeWriterKind {
+      if (typeof kind === "object") {
+        return kind;
+      }
       switch (kind) {
         case "inheritPiped":
         case "inherit":
@@ -690,6 +693,9 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
     return [stdoutBuffer, stderrBuffer, undefined] as const;
 
     function getOutputBuffer(innerWriter: Deno.WriterSync, kind: ShellPipeWriterKind) {
+      if (typeof kind === "object") {
+        return kind;
+      }
       switch (kind) {
         case "inherit":
           if (hasProgressBars) {
@@ -712,7 +718,7 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
   }
 
   function finalizeCommandResultBuffer(
-    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter,
+    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter | Deno.WriterSync,
   ): BufferStdio {
     if (buffer instanceof CapturingBufferWriter) {
       return buffer.getBuffer();
@@ -723,12 +729,15 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
       buffer.close();
       return buffer.getBuffer() ?? "streamed";
     } else {
+      if (typeof buffer === "object") {
+        return "streamed";
+      }
       return buffer;
     }
   }
 
   function finalizeCommandResultBufferForError(
-    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter,
+    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter | Deno.WriterSync,
     error: Error,
   ) {
     if (buffer instanceof InheritStaticTextBypassWriter) {

--- a/src/deps.test.ts
+++ b/src/deps.test.ts
@@ -7,7 +7,7 @@ export {
   assertRejects,
   assertStringIncludes,
   assertThrows,
-} from "https://deno.land/std@0.201.0/testing/asserts.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 export { readerFromStreamReader } from "https://deno.land/std@0.201.0/streams/reader_from_stream_reader.ts";
 export { writableStreamFromWriter } from "https://deno.land/std@0.201.0/streams/writable_stream_from_writer.ts";
 export { serve } from "https://deno.land/std@0.201.0/http/server.ts";

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -11,7 +11,7 @@ export type ShellPipeReader = "inherit" | "null" | Deno.Reader;
  * @value "piped" - Captures the pipe without outputting.
  * @value "inheritPiped" - Captures the pipe with outputting.
  */
-export type ShellPipeWriterKind = "inherit" | "null" | "piped" | "inheritPiped";
+export type ShellPipeWriterKind = "inherit" | "null" | "piped" | "inheritPiped" | Deno.WriterSync;
 
 export class NullPipeWriter implements Deno.WriterSync {
   writeSync(p: Uint8Array): number {


### PR DESCRIPTION
Usage: 

```typescript
import { $ } from "./mod.ts";

await $`echo "Hello, world!"`.stdout(Deno.stderr);
```