### PR TITLE
fix: export some non-exported types

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -30,16 +30,19 @@ import { wasmInstance } from "./src/lib/mod.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { createPathRef, PathRef } from "./src/path.ts";
 
+export type { Delay, DelayIterator } from "./src/common.ts";
 export { FsFileWrapper, PathRef } from "./src/path.ts";
-export type { PathSymlinkOptions, SymlinkOptions, WalkEntry } from "./src/path.ts";
-export { CommandBuilder, CommandResult, KillSignal, KillSignalController } from "./src/command.ts";
+export type { ExpandGlobOptions, PathSymlinkOptions, SymlinkOptions, WalkEntry, WalkOptions } from "./src/path.ts";
+export { CommandBuilder, CommandChild, CommandResult, KillSignal, KillSignalController } from "./src/command.ts";
 export type { CommandContext, CommandHandler, CommandPipeReader, CommandPipeWriter } from "./src/command_handler.ts";
+export type { ShellPipeReader, ShellPipeWriterKind } from "./src/pipes.ts";
 export type {
   ConfirmOptions,
   MultiSelectOption,
   MultiSelectOptions,
   ProgressBar,
   ProgressOptions,
+  PromptInputMask,
   PromptOptions,
   SelectOptions,
 } from "./src/console/mod.ts";
@@ -53,6 +56,7 @@ export type {
   ExitExecuteResult,
   SetEnvVarChange,
   SetShellVarChange,
+  UnsetVarChange,
 } from "./src/result.ts";
 
 /**
@@ -103,6 +107,22 @@ export type $Type<TExtras extends ExtrasObject = {}> =
 export interface $Template {
   (strings: TemplateStringsArray, ...exprs: any[]): CommandBuilder;
 }
+
+/**
+ * `outdent` from the https://deno.land/x/outdent module.
+ * @internal
+ */
+type Outdent = typeof import("./src/deps.ts").outdent;
+/**
+ * `which` from the https://deno.land/x/which module.
+ * @internal
+ */
+type Which = typeof import("./src/deps.ts").which;
+/**
+ * `whichSync` from the https://deno.land/x/which module.
+ * @internal
+ */
+type WhichSync = typeof import("./src/deps.ts").whichSync;
 
 export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
   /**
@@ -206,7 +226,7 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    * closing line will be removed from the output,
    * so that only the content in between remains.
    */
-  dedent: typeof outdent;
+  dedent: Outdent;
   /**
    * Determines if the provided command exists resolving to `true` if the command
    * will be resolved by the shell of the current `$` or false otherwise.
@@ -462,9 +482,9 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    */
   withRetries<TReturn>(opts: RetryOptions<TReturn>): Promise<TReturn>;
   /** Re-export of `deno_which` for getting the path to an executable. */
-  which: typeof which;
+  which: Which;
   /** Similar to `which`, but synchronously. */
-  whichSync: typeof whichSync;
+  whichSync: WhichSync;
 }
 
 function sleep(delay: Delay) {
@@ -509,6 +529,7 @@ function cd(path: string | URL | ImportMeta | PathRef) {
   Deno.chdir(path.toString());
 }
 
+/** @internal */
 type ExtrasObject = Record<string, (...args: any[]) => unknown>;
 
 interface $State<TExtras extends ExtrasObject> {

--- a/src/command.ts
+++ b/src/command.ts
@@ -748,6 +748,7 @@ export class CommandResult {
   /** The exit code. */
   readonly code: number;
 
+  /** @internal */
   constructor(code: number, stdout: BufferStdio, stderr: BufferStdio, combined: Buffer | undefined) {
     this.code = code;
     this.#stdout = stdout;

--- a/src/console/mod.ts
+++ b/src/console/mod.ts
@@ -6,6 +6,6 @@ export type { MultiSelectOption, MultiSelectOptions } from "./multiSelect.ts";
 export type { ProgressOptions } from "./progress/mod.ts";
 export { isShowingProgressBars, ProgressBar } from "./progress/mod.ts";
 export { maybePrompt, prompt } from "./prompt.ts";
-export type { PromptOptions } from "./prompt.ts";
+export type { PromptInputMask, PromptOptions } from "./prompt.ts";
 export { maybeSelect, select } from "./select.ts";
 export type { SelectOptions } from "./select.ts";

--- a/src/console/progress/mod.ts
+++ b/src/console/progress/mod.ts
@@ -136,7 +136,7 @@ export class ProgressBar {
 
   /** Does the provided action and will call `.finish()` when this is the last `.with(...)` action that runs. */
   with<TResult>(action: () => TResult): TResult;
-  async with<TResult>(action: () => Promise<TResult>): Promise<TResult>;
+  with<TResult>(action: () => Promise<TResult>): Promise<TResult>;
   with<TResult>(action: () => Promise<TResult> | TResult): Promise<TResult> | TResult {
     this.#withCount++;
     let wasAsync = false;

--- a/src/console/prompt.ts
+++ b/src/console/prompt.ts
@@ -17,7 +17,7 @@ export interface PromptOptions {
    * types (`false` by default).
    * @default `false`
    */
-  mask?: InputMask | boolean;
+  mask?: PromptInputMask | boolean;
   /**
    * Whether to not clear the prompt text on selection.
    * @default `false`
@@ -26,14 +26,14 @@ export interface PromptOptions {
 }
 
 /** Configuration of the prompt input mask */
-export interface InputMask {
+export interface PromptInputMask {
   /** The character used to mask input (`*` by default) */
   char?: string;
   /** Whether or not to keep the last character "unmasked" (`false` by default) */
   lastVisible?: boolean;
 }
 
-const defaultMask: Required<InputMask> = { char: "*", lastVisible: false };
+const defaultMask: Required<PromptInputMask> = { char: "*", lastVisible: false };
 
 export function prompt(optsOrMessage: PromptOptions | string, options?: Omit<PromptOptions, "message">) {
   return maybePrompt(optsOrMessage, options).then(resultOrExit);
@@ -95,7 +95,7 @@ export function innerPrompt(
 interface DrawState {
   title: string;
   inputText: string;
-  mask: InputMask | false;
+  mask: PromptInputMask | false;
   hasCompleted: boolean;
 }
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -14,11 +14,16 @@ import {
   writeAllSync,
 } from "./deps.ts";
 
-export type ExpandGlobOptions = import("./deps.ts").ExpandGlobOptions;
-export type WalkOptions = import("./deps.ts").WalkOptions;
+/** @internal */
+type DenoStdExpandGlobOptions = import("./deps.ts").ExpandGlobOptions;
+export type ExpandGlobOptions = DenoStdExpandGlobOptions;
+/** @internal */
+type DenoStdWalkOptions = import("./deps.ts").WalkOptions;
+export type WalkOptions = DenoStdWalkOptions;
 
 const PERIOD_CHAR_CODE = ".".charCodeAt(0);
 
+/** @internal */
 export function createPathRef(path: string | URL | ImportMeta | PathRef): PathRef {
   if (path instanceof PathRef) {
     return path;

--- a/src/path.ts
+++ b/src/path.ts
@@ -14,10 +14,16 @@ import {
   writeAllSync,
 } from "./deps.ts";
 
-/** @internal */
+/**
+ * `ExpandGlobOptions` from https://deno.land/std/fs/expand_glob.ts
+ * @internal
+ */
 type DenoStdExpandGlobOptions = import("./deps.ts").ExpandGlobOptions;
 export type ExpandGlobOptions = DenoStdExpandGlobOptions;
-/** @internal */
+/**
+ * `WalkOptions` from https://deno.land/std/fs/walk.ts
+ * @internal
+ */
 type DenoStdWalkOptions = import("./deps.ts").WalkOptions;
 export type WalkOptions = DenoStdWalkOptions;
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -342,6 +342,7 @@ export class RequestResult {
   #downloadResponse: Response;
   #originalUrl: string;
 
+  /** @internal */
   constructor(opts: {
     response: Response;
     originalUrl: string;


### PR DESCRIPTION
This was discovered with the new `--lint` flag that's upcoming in Deno 1.38 (`deno doc --lint mod.ts`).