### PR TITLE
fix: `escapeArg` was not escaping multiple quotes

### DIFF
--- a/src/command.test.ts
+++ b/src/command.test.ts
@@ -3,5 +3,6 @@ import { assertEquals } from "./deps.test.ts";
 
 Deno.test("escapes arg", () => {
   assertEquals(escapeArg("hello"), "hello");
+  assertEquals(escapeArg(""), "''");
   assertEquals(escapeArg("'abc'"), `''"'"'abc'"'"''`);
 });

--- a/src/command.test.ts
+++ b/src/command.test.ts
@@ -1,0 +1,7 @@
+import { escapeArg } from "./command.ts";
+import { assertEquals } from "./deps.test.ts";
+
+Deno.test("escapes arg", () => {
+  assertEquals(escapeArg("hello"), "hello");
+  assertEquals(escapeArg("'abc'"), `''"'"'abc'"'"''`);
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -867,10 +867,10 @@ function buildEnv(env: Record<string, string | undefined>) {
 
 export function escapeArg(arg: string) {
   // very basic for now
-  if (/^[A-Za-z0-9]*$/.test(arg)) {
+  if (/^[A-Za-z0-9]+$/.test(arg)) {
     return arg;
   } else {
-    return `'${arg.replace("'", `'"'"'`)}'`;
+    return `'${arg.replaceAll("'", `'"'"'`)}'`;
   }
 }
 


### PR DESCRIPTION
```ts
import $ from "https://deno.land/x/dax/mod.ts";
import $2 from "./mod.ts"; // this branch

await $2`echo ${`'abc'`}`; // 'abc'
await $`echo ${`'abc'`}`; // error: Uncaught "Expected closing single quote.\n  '\n  ~"
```
