### PR TITLE
fix: empty strings were ignored

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1651,6 +1651,11 @@ Deno.test("ensure KillSignalController readme example works", async () => {
   assert(endTime - startTime < 1000);
 });
 
+Deno.test("should support empty quoted string", async () => {
+  const output = await $`echo '' test ''`.text();
+  assertEquals(output, " test ");
+});
+
 function ensurePromiseNotResolved(promise: Promise<unknown>) {
   return new Promise<void>((resolve, reject) => {
     promise.then(() => reject(new Error("Promise was resolved")));

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1245,8 +1245,11 @@ Deno.test("copy test", async () => {
       "cp: target 'non-existent' is not a directory\n",
     );
 
-    assertEquals(await getStdErr($`cp "" ""`), "cp: missing file operand\n");
-    assertStringIncludes(await getStdErr($`cp ${file1} ""`), "cp: missing destination file operand after");
+    assertEquals(await getStdErr($`cp`), "cp: missing file operand\n");
+    assertStringIncludes(await getStdErr($`cp ${file1}`), "cp: missing destination file operand after");
+
+    assertEquals(await getStdErr($`cp`), "cp: missing file operand\n");
+    assertStringIncludes(await getStdErr($`cp ${file1}`), "cp: missing destination file operand after");
 
     // recursive test
     destDir.join("sub_dir").mkdirSync();
@@ -1311,8 +1314,8 @@ Deno.test("move test", async () => {
       "mv: target 'non-existent' is not a directory\n",
     );
 
-    assertEquals(await getStdErr($`mv "" ""`), "mv: missing operand\n");
-    assertStringIncludes(await getStdErr($`mv ${file1} ""`), "mv: missing destination file operand after");
+    assertEquals(await getStdErr($`mv`), "mv: missing operand\n");
+    assertStringIncludes(await getStdErr($`mv ${file1}`), "mv: missing destination file operand after");
   });
 });
 


### PR DESCRIPTION
`deno eval ''` should succeed and output nothing.

```ts
await $`deno eval ''`;
// error: the following required arguments were not provided:
// ...
```

## test

```sh
#!/bin/sh
# ./test.sh: Output the number of arguments ($#) and the value of each argument
printf '$#: %d\n' $#

for i in "$@"; do
  printf '  [%s]\n' "$i"
done
```

```ts
import $ from "https://deno.land/x/dax/mod.ts";
import $2 from "./mod.ts"; // this branch

Deno.env.set("X", "yyy      zzzz");

console.log("master:");
await $`./test.sh`.printCommand();
await $`./test.sh A 'B' "C"`.printCommand();
await $`./test.sh A "" ""`.printCommand();
await $`./test.sh $X"$X"'$X'`.printCommand();

console.log("\n\nPR:");
await $2`./test.sh`.printCommand();
await $2`./test.sh A 'B' "C"`.printCommand();
await $2`./test.sh A '' ""`.printCommand();
await $2`./test.sh $X"$X"'$X'`.printCommand();

console.log("\n\nBash:");

await runBash(`./test.sh`);
await runBash(`./test.sh A 'B' "C"`);
await runBash(`./test.sh A '' ""`);
await runBash(`./test.sh $X"$X"'$X'`);

async function runBash(cmd: string) {
  console.log(`> bash -c ${cmd}`);
  await new Deno.Command("bash", {
    args: ["-c", cmd],
    stdout: "inherit",
  }).spawn();
}
```


```
> ./test.sh
$#: 0
> ./test.sh A 'B' "C"
$#: 3
  [A]
  [B]
  [C]
> ./test.sh A "" ""
$#: 1
  [A]
> ./test.sh $X"$X"'$X'
$#: 2
  [yyy]
  [zzzzyyy zzzz$X]


PR:
> ./test.sh
$#: 0
> ./test.sh A 'B' "C"
$#: 3
  [A]
  [B]
  [C]
> ./test.sh A '' ""
$#: 3
  [A]
  []
  []
> ./test.sh $X"$X"'$X'
$#: 2
  [yyy]
  [zzzzyyy      zzzz$X]


Bash:
> bash -c ./test.sh
> bash -c ./test.sh A 'B' "C"
$#: 0
> bash -c ./test.sh A '' ""
$#: 3
  [A]
  [B]
  [C]
> bash -c ./test.sh $X"$X"'$X'
$#: 3
  [A]
  []
  []
$#: 2
  [yyy]
  [zzzzyyy      zzzz$X]
```