### PR TITLE
refactor: switch to local interfaces for `Deno.Reader`, `WriterSync`, `Closer`

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1651,6 +1651,11 @@ Deno.test("ensure KillSignalController readme example works", async () => {
   assert(endTime - startTime < 1000);
 });
 
+Deno.test("should support empty quoted string", async () => {
+  const output = await $`echo '' test ''`.text();
+  assertEquals(output, " test ");
+});
+
 function ensurePromiseNotResolved(promise: Promise<unknown>) {
   return new Promise<void>((resolve, reject) => {
     promise.then(() => reject(new Error("Promise was resolved")));

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1245,8 +1245,11 @@ Deno.test("copy test", async () => {
       "cp: target 'non-existent' is not a directory\n",
     );
 
-    assertEquals(await getStdErr($`cp "" ""`), "cp: missing file operand\n");
-    assertStringIncludes(await getStdErr($`cp ${file1} ""`), "cp: missing destination file operand after");
+    assertEquals(await getStdErr($`cp`), "cp: missing file operand\n");
+    assertStringIncludes(await getStdErr($`cp ${file1}`), "cp: missing destination file operand after");
+
+    assertEquals(await getStdErr($`cp`), "cp: missing file operand\n");
+    assertStringIncludes(await getStdErr($`cp ${file1}`), "cp: missing destination file operand after");
 
     // recursive test
     destDir.join("sub_dir").mkdirSync();
@@ -1311,8 +1314,8 @@ Deno.test("move test", async () => {
       "mv: target 'non-existent' is not a directory\n",
     );
 
-    assertEquals(await getStdErr($`mv "" ""`), "mv: missing operand\n");
-    assertStringIncludes(await getStdErr($`mv ${file1} ""`), "mv: missing destination file operand after");
+    assertEquals(await getStdErr($`mv`), "mv: missing operand\n");
+    assertStringIncludes(await getStdErr($`mv ${file1}`), "mv: missing destination file operand after");
   });
 });
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -730,7 +730,7 @@ Deno.test("abort", async () => {
 });
 
 Deno.test("piping to stdin", async () => {
-  // Deno.Reader
+  // Reader
   {
     const bytes = new TextEncoder().encode("test\n");
     const result =
@@ -768,7 +768,7 @@ Deno.test("piping to stdin", async () => {
   }
 });
 
-Deno.test("spawning a command twice that has stdin set to a Deno.Reader should error", async () => {
+Deno.test("spawning a command twice that has stdin set to a Reader should error", async () => {
   const bytes = new TextEncoder().encode("test\n");
   const command = $`deno eval "const b = new Uint8Array(4); await Deno.stdin.read(b); await Deno.stdout.write(b);"`
     .stdin(new Buffer(bytes));

--- a/mod.ts
+++ b/mod.ts
@@ -35,7 +35,7 @@ export { FsFileWrapper, PathRef } from "./src/path.ts";
 export type { ExpandGlobOptions, PathSymlinkOptions, SymlinkOptions, WalkEntry, WalkOptions } from "./src/path.ts";
 export { CommandBuilder, CommandChild, CommandResult, KillSignal, KillSignalController } from "./src/command.ts";
 export type { CommandContext, CommandHandler, CommandPipeReader, CommandPipeWriter } from "./src/command_handler.ts";
-export type { ShellPipeReader, ShellPipeWriterKind } from "./src/pipes.ts";
+export type { Closer, Reader, ShellPipeReader, ShellPipeWriterKind, WriterSync } from "./src/pipes.ts";
 export type {
   ConfirmOptions,
   MultiSelectOption,

--- a/src/command.ts
+++ b/src/command.ts
@@ -21,9 +21,11 @@ import {
   InheritStaticTextBypassWriter,
   NullPipeWriter,
   PipedBuffer,
+  Reader,
   ShellPipeReader,
   ShellPipeWriter,
   ShellPipeWriterKind,
+  WriterSync,
 } from "./pipes.ts";
 import { parseCommand, spawn } from "./shell.ts";
 import { isShowingProgressBars } from "./console/progress/interval.ts";
@@ -33,7 +35,7 @@ type BufferStdio = "inherit" | "null" | "streamed" | Buffer;
 
 interface CommandBuilderState {
   command: string | undefined;
-  stdin: "inherit" | "null" | Box<Deno.Reader | ReadableStream<Uint8Array> | "consumed">;
+  stdin: "inherit" | "null" | Box<Reader | ReadableStream<Uint8Array> | "consumed">;
   combinedStdoutStderr: boolean;
   stdoutKind: ShellPipeWriterKind;
   stderrKind: ShellPipeWriterKind;
@@ -692,7 +694,7 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
     }
     return [stdoutBuffer, stderrBuffer, undefined] as const;
 
-    function getOutputBuffer(innerWriter: Deno.WriterSync, kind: ShellPipeWriterKind) {
+    function getOutputBuffer(innerWriter: WriterSync, kind: ShellPipeWriterKind) {
       if (typeof kind === "object") {
         return kind;
       }
@@ -718,7 +720,7 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
   }
 
   function finalizeCommandResultBuffer(
-    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter | Deno.WriterSync,
+    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter | WriterSync,
   ): BufferStdio {
     if (buffer instanceof CapturingBufferWriter) {
       return buffer.getBuffer();
@@ -736,7 +738,7 @@ export function parseAndSpawnCommand(state: CommandBuilderState) {
   }
 
   function finalizeCommandResultBufferForError(
-    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter | Deno.WriterSync,
+    buffer: PipedBuffer | "inherit" | "null" | CapturingBufferWriter | InheritStaticTextBypassWriter | WriterSync,
     error: Error,
   ) {
     if (buffer instanceof InheritStaticTextBypassWriter) {

--- a/src/command_handler.ts
+++ b/src/command_handler.ts
@@ -1,11 +1,12 @@
 import { ExecuteResult } from "./result.ts";
 import type { KillSignal } from "./command.ts";
+import { Reader, WriterSync } from "./pipes.ts";
 
 /** Used to read from stdin. */
-export type CommandPipeReader = "inherit" | "null" | Deno.Reader;
+export type CommandPipeReader = "inherit" | "null" | Reader;
 
 /** Used to write to stdout or stderr. */
-export interface CommandPipeWriter extends Deno.WriterSync {
+export interface CommandPipeWriter extends WriterSync {
   writeSync(p: Uint8Array): number;
   writeText(text: string): void;
   writeLine(text: string): void;

--- a/src/commands/cat.ts
+++ b/src/commands/cat.ts
@@ -26,7 +26,7 @@ async function executeCat(context: CommandContext) {
 
   for (const path of flags.paths) {
     if (path === "-") { // read from stdin
-      if (typeof context.stdin === "object") { // stdin is a Deno.Reader
+      if (typeof context.stdin === "object") { // stdin is a Reader
         while (true) {
           const size = await context.stdin.read(buf);
           if (!size || size === 0) break;

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,6 @@
 import { logger } from "./console/mod.ts";
 import { BufReader, path } from "./deps.ts";
+import { Reader } from "./pipes.ts";
 
 /**
  * Delay used for certain actions.
@@ -216,7 +217,7 @@ export interface ShebangInfo {
 }
 
 const decoder = new TextDecoder();
-export async function getExecutableShebang(reader: Deno.Reader): Promise<ShebangInfo | undefined> {
+export async function getExecutableShebang(reader: Reader): Promise<ShebangInfo | undefined> {
   const text = "#!/usr/bin/env ";
   const buffer = new Uint8Array(text.length);
   const bytesReadCount = await reader.read(buffer);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,7 +3,7 @@ import { CommandContext, CommandHandler } from "./command_handler.ts";
 import { getExecutableShebangFromPath, ShebangInfo } from "./common.ts";
 import { DenoWhichRealEnvironment, fs, path, which } from "./deps.ts";
 import { wasmInstance } from "./lib/mod.ts";
-import { ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind } from "./pipes.ts";
+import { Reader, ShellPipeReader, ShellPipeWriter, ShellPipeWriterKind, WriterSync } from "./pipes.ts";
 import { EnvChange, ExecuteResult, getAbortedResult, resultFromCode } from "./result.ts";
 
 export interface SequentialList {
@@ -670,7 +670,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
     await pipeReaderToWriterSync(readable, writer, new AbortController().signal);
   }
 
-  async function pipeReaderToWriter(reader: Deno.Reader, writable: WritableStream<Uint8Array>, signal: AbortSignal) {
+  async function pipeReaderToWriter(reader: Reader, writable: WritableStream<Uint8Array>, signal: AbortSignal) {
     const abortedPromise = new Promise<void>((resolve) => {
       signal.addEventListener("abort", listener);
       function listener() {
@@ -695,7 +695,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
 
   async function pipeReaderToWriterSync(
     readable: ReadableStream<Uint8Array>,
-    writer: Deno.WriterSync,
+    writer: WriterSync,
     signal: AbortSignal,
   ) {
     const reader = readable.getReader();


### PR DESCRIPTION
Since they're sadly deprecated.