### PR TITLE
docs: show shebang in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Cross platform shell tools for Deno inspired by [zx](https://github.com/google/z
 ## Executing commands
 
 ```ts
+#!/usr/bin/env -S deno run --allow-all
 import $ from "https://deno.land/x/dax/mod.ts";
 
 // run a command


### PR DESCRIPTION
I often use dax for one of scripts, which I `chmod a+x`. Howevere, I always have to google the appropriate deno hash bang. It feels like including it in the example might save some googleing for someone, and maybe also teach people that they can chmod+x dax scripts?