### PR TITLE
feat: add `.pipe(...)` for piping stdout of a command to another command

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -797,7 +797,7 @@ Deno.test("piping to stdin", async () => {
     assertEquals(result, "1\n2");
   }
 
-  // command that exists via stdin
+  // command that exits via stdin
   {
     const child = $`echo 1 && echo 2 && exit 1`;
     const result = await $`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stdout.writable);'`
@@ -806,6 +806,18 @@ Deno.test("piping to stdin", async () => {
       .noThrow();
     assertEquals(result.code, 1);
     assertEquals(result.stderr, "stdin pipe broken. Error: Exited with code: 1\n");
+  }
+});
+
+Deno.test("pipe", async () => {
+  {
+    const result = await $`echo 1 && echo 2`
+      .pipe($`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stderr.writable);'`)
+      .stderr("piped")
+      .stdout("piped")
+      .spawn();
+    assertEquals(result.stdout, "");
+    assertEquals(result.stderr, "1\n2\n");
   }
 });
 


### PR DESCRIPTION
Adds a new `.pipe(...)` method for piping one command to another. The critical part of this is that `.pipe(...)` returns the provided command and not the original command. This allows for chaining multiple commands together like so:

```ts
const result = const lineCount = await $`echo 1 && echo 2`
  .pipe($`wc -l`)
  .text(); // text of the result of wc -l
```

---

I was initially thinking this should be:

```ts
await $`echo 1`
  .stdout($`deno eval 'await Deno.stdin.readable.pipeTo(Deno.stderr.writable);'`);
```

...however, it gets confusing about what command someone is acting on when both `.stdout` and `stderr` are set and it becomes ambiguous about what the return value of those methods are.

Closes #137