### PR TITLE
feat: remove need for `kind: "continue"` in custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ You can also register your own custom commands using the `registerCommand` or `r
 const commandBuilder = new CommandBuilder()
   .registerCommand(
     "true",
-    () => Promise.resolve({ kind: "continue", code: 0 }),
+    () => Promise.resolve({ code: 0 }),
   );
 
 const result = await commandBuilder

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -378,19 +378,17 @@ Deno.test("should support custom command handlers", async () => {
       if (context.args.length != 1) {
         context.stderr.writeLine("zardoz-speaks: expected 1 argument");
         return {
-          kind: "continue",
           code: 1,
         };
       }
       context.stdout.writeLine(`zardoz speaks to ${context.args[0]}`);
       return {
-        kind: "continue",
         code: 0,
       };
     })
     .registerCommands({
-      "true": () => Promise.resolve({ kind: "continue", code: 0 }),
-      "false": () => Promise.resolve({ kind: "continue", code: 1 }),
+      "true": () => Promise.resolve({ code: 0 }),
+      "false": () => Promise.resolve({ code: 1 }),
     }).stderr("piped").stdout("piped");
 
   {
@@ -425,7 +423,6 @@ Deno.test("should not allow invalid command names", () => {
   const hax: CommandHandler = (context: CommandContext) => {
     context.stdout.writeLine("h4x!1!");
     return {
-      kind: "continue",
       code: 0,
     };
   };
@@ -1576,7 +1573,7 @@ Deno.test("$.commandExists", async () => {
 
   const $new = build$({
     commandBuilder: new CommandBuilder().registerCommand("some-fake-command", () => {
-      return Promise.resolve({ code: 0, kind: "continue" });
+      return Promise.resolve({ code: 0 });
     }),
   });
   assertEquals(await $new.commandExists("some-fake-command"), true);
@@ -1588,7 +1585,7 @@ Deno.test("$.commandExistsSync", () => {
 
   const $new = build$({
     commandBuilder: new CommandBuilder().registerCommand("some-fake-command", () => {
-      return Promise.resolve({ code: 0, kind: "continue" });
+      return Promise.resolve({ code: 0 });
     }),
   });
   assertEquals($new.commandExistsSync("some-fake-command"), true);
@@ -1759,7 +1756,6 @@ Deno.test("signal listening in registered commands", async () => {
       function listener(signal: Deno.Signal) {
         if (signal === "SIGKILL") {
           resolve({
-            kind: "continue",
             code: 135,
           });
           handler.signal.removeListener(listener);

--- a/src/commands/cat.ts
+++ b/src/commands/cat.ts
@@ -1,5 +1,5 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 import { bailUnsupported, parseArgKinds } from "./args.ts";
 import { path as pathUtils } from "../deps.ts";
 
@@ -11,11 +11,11 @@ export async function catCommand(
   context: CommandContext,
 ): Promise<ExecuteResult> {
   try {
-    const exit_code = await executeCat(context);
-    return resultFromCode(exit_code);
+    const code = await executeCat(context);
+    return { code };
   } catch (err) {
     context.stderr.writeLine(`cat: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,13 +1,12 @@
 import { CommandContext } from "../command_handler.ts";
 import { resolvePath } from "../common.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 
 export async function cdCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
     const dir = await executeCd(context.cwd, context.args);
     return {
       code: 0,
-      kind: "continue",
       changes: [{
         kind: "cd",
         dir,
@@ -15,7 +14,7 @@ export async function cdCommand(context: CommandContext): Promise<ExecuteResult>
     };
   } catch (err) {
     context.stderr.writeLine(`cd: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/cp_mv.ts
+++ b/src/commands/cp_mv.ts
@@ -1,5 +1,5 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 import { bailUnsupported, parseArgKinds } from "./args.ts";
 import { resolvePath, safeLstat } from "../common.ts";
 import { path } from "../deps.ts";
@@ -9,10 +9,10 @@ export async function cpCommand(
 ): Promise<ExecuteResult> {
   try {
     await executeCp(context.cwd, context.args);
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`cp: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 
@@ -99,10 +99,10 @@ export async function mvCommand(
 ): Promise<ExecuteResult> {
   try {
     await executeMove(context.cwd, context.args);
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`mv: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/echo.ts
+++ b/src/commands/echo.ts
@@ -1,7 +1,7 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 
 export function echoCommand(context: CommandContext): ExecuteResult {
   context.stdout.writeLine(context.args.join(" "));
-  return resultFromCode(0);
+  return { code: 0 };
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -15,7 +15,6 @@ export function exportCommand(context: CommandContext): ExecuteResult {
     }
   }
   return {
-    kind: "continue",
     code: 0,
     changes,
   };

--- a/src/commands/mkdir.ts
+++ b/src/commands/mkdir.ts
@@ -1,6 +1,6 @@
 import { CommandContext } from "../command_handler.ts";
 import { resolvePath } from "../common.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 import { safeLstat } from "../common.ts";
 import { bailUnsupported, parseArgKinds } from "./args.ts";
 
@@ -9,10 +9,10 @@ export async function mkdirCommand(
 ): Promise<ExecuteResult> {
   try {
     await executeMkdir(context.cwd, context.args);
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`mkdir: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/printenv.ts
+++ b/src/commands/printenv.ts
@@ -1,5 +1,5 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 
 export function printEnvCommand(context: CommandContext): ExecuteResult {
   // windows expects env vars to be upcased
@@ -14,12 +14,12 @@ export function printEnvCommand(context: CommandContext): ExecuteResult {
     const result = executePrintEnv(context.env, args);
     context.stdout.writeLine(result);
     if (args.some((arg) => context.env[arg] === undefined)) {
-      return resultFromCode(1);
+      return { code: 1 };
     }
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`printenv: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/pwd.ts
+++ b/src/commands/pwd.ts
@@ -1,16 +1,16 @@
 import { CommandContext } from "../command_handler.ts";
 import { path } from "../deps.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 import { bailUnsupported, parseArgKinds } from "./args.ts";
 
 export function pwdCommand(context: CommandContext): ExecuteResult {
   try {
     const output = executePwd(context.cwd, context.args);
     context.stdout.writeLine(output);
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`pwd: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -1,6 +1,6 @@
 import { CommandContext } from "../command_handler.ts";
 import { resolvePath } from "../common.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 import { ArgKind, parseArgKinds } from "./args.ts";
 
 export async function rmCommand(
@@ -8,10 +8,10 @@ export async function rmCommand(
 ): Promise<ExecuteResult> {
   try {
     await executeRemove(context.cwd, context.args);
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`rm: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/sleep.ts
+++ b/src/commands/sleep.ts
@@ -1,5 +1,5 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, getAbortedResult, resultFromCode } from "../result.ts";
+import { ExecuteResult, getAbortedResult } from "../result.ts";
 
 export async function sleepCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
@@ -24,10 +24,10 @@ export async function sleepCommand(context: CommandContext): Promise<ExecuteResu
     if (context.signal.aborted) {
       return getAbortedResult();
     }
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`sleep: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,7 +1,7 @@
 import { CommandContext } from "../command_handler.ts";
 import { resolvePath, safeLstat } from "../common.ts";
 import { fs } from "../deps.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 
 export async function testCommand(context: CommandContext): Promise<ExecuteResult> {
   try {
@@ -31,11 +31,11 @@ export async function testCommand(context: CommandContext): Promise<ExecuteResul
       default:
         throw new Error("unsupported test type");
     }
-    return resultFromCode(result ? 0 : 1);
+    return { code: result ? 0 : 1 };
   } catch (err) {
     context.stderr.writeLine(`test: ${err?.message ?? err}`);
     // bash test returns 2 on error, e.g. -bash: test: -8: unary operator expected
-    return resultFromCode(2);
+    return { code: 2 };
   }
 }
 

--- a/src/commands/touch.ts
+++ b/src/commands/touch.ts
@@ -1,14 +1,13 @@
 import { CommandContext } from "../command_handler.ts";
-import { resultFromCode } from "../result.ts";
 import { bailUnsupported, parseArgKinds } from "./args.ts";
 
 export async function touchCommand(context: CommandContext) {
   try {
     await executetouch(context.args);
-    return resultFromCode(0);
+    return { code: 0 };
   } catch (err) {
     context.stderr.writeLine(`touch: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/commands/unset.ts
+++ b/src/commands/unset.ts
@@ -1,16 +1,15 @@
 import { CommandContext } from "../command_handler.ts";
-import { ExecuteResult, resultFromCode } from "../result.ts";
+import { ExecuteResult } from "../result.ts";
 
 export function unsetCommand(context: CommandContext): ExecuteResult {
   try {
     return {
-      kind: "continue",
       code: 0,
       changes: parseNames(context.args).map((name) => ({ kind: "unsetvar", name })),
     };
   } catch (err) {
     context.stderr.writeLine(`unset: ${err?.message ?? err}`);
-    return resultFromCode(1);
+    return { code: 1 };
   }
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,13 +1,6 @@
 /** Result of executing a custom command. */
 export type ExecuteResult = ExitExecuteResult | ContinueExecuteResult;
 
-export function resultFromCode(code: number): ContinueExecuteResult {
-  return {
-    kind: "continue",
-    code,
-  };
-}
-
 export function getAbortedResult(): ExecuteResult {
   return {
     kind: "exit",
@@ -26,7 +19,7 @@ export interface ExitExecuteResult {
 /** Tells the shell to continue executing. */
 export interface ContinueExecuteResult {
   /** Discriminator. */
-  kind: "continue";
+  kind?: undefined;
   /** Exit code to use. */
   code: number;
   /** Changes to the shell that should occur (ex. unsetting env vars). */


### PR DESCRIPTION
Instead of writing:

```ts
return {
  kind: "continue",
  code: 0,
};
```

You can now just do:

```ts
return { code: 0 };
```
