### PR TITLE
feat: ability to abort request's response

### DIFF
--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -279,7 +279,7 @@ Deno.test("$.request", (t) => {
       );
     });
 
-    step("ensure times out  waiting for body", async () => {
+    step("ensure times out waiting for body", async () => {
       const request = new RequestBuilder()
         .url(new URL("/sleep-body/10000", serverUrl))
         .timeout(50)
@@ -292,6 +292,21 @@ Deno.test("$.request", (t) => {
         caughtErr = err;
       }
       assertEquals(caughtErr, "Request timed out after 50 milliseconds.");
+    });
+
+    step("ability to abort while waiting", async () => {
+      const request = new RequestBuilder()
+        .url(new URL("/sleep-body/10000", serverUrl))
+        .showProgress();
+      const response = await request.fetch();
+      let caughtErr: unknown;
+      try {
+        response.abort("Cancel.");
+        await response.text();
+      } catch (err) {
+        caughtErr = err;
+      }
+      assertEquals(caughtErr, "Cancel.");
     });
 
     await Promise.all(steps);

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -299,9 +299,9 @@ Deno.test("$.request", (t) => {
         .url(new URL("/sleep-body/10000", serverUrl))
         .showProgress();
       const response = await request.fetch();
+      response.abort("Cancel.");
       let caughtErr: unknown;
       try {
-        response.abort("Cancel.");
         await response.text();
       } catch (err) {
         caughtErr = err;


### PR DESCRIPTION
Adds the ability to abort a request's response (note: use `.timeout(...)` to do timeouts):

```ts
const response = await $.request("https://plugins.dprint.dev/info.json");

response.abort();

const text = await response.text(); // throws because aborted
```