### PR TITLE
feat: error when providing an unexpected object that doesn't override `toString()` in a command expr

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -169,6 +169,35 @@ Deno.test("should throw when exit code is non-zero", async () => {
   );
 });
 
+Deno.test("throws when providing an object that doesn't override toString", async () => {
+  {
+    const obj1 = {};
+    assertThrows(
+      () => $`echo ${obj1}`,
+      Error,
+      "Failed resolving expression in command. Provided object does not override `toString()`.",
+    );
+  }
+  {
+    const obj2 = {
+      toString() {
+        return "1";
+      },
+    };
+    const result = await $`echo ${obj2}`.text();
+    assertEquals(result, "1");
+  }
+  class Test {
+    toString() {
+      return 1;
+    }
+  }
+  {
+    const result = await $`echo ${new Test()}`.text();
+    assertEquals(result, "1");
+  }
+});
+
 Deno.test("should change the cwd, but only in the shell", async () => {
   const output = await $`cd src ; deno eval 'console.log(Deno.cwd());'`.stdout("piped");
   const standardizedOutput = output.stdout.trim().replace(/\\/g, "/");

--- a/src/command.ts
+++ b/src/command.ts
@@ -1418,13 +1418,13 @@ function detectInputOrOutputRedirect(text: string) {
 
 function templateLiteralExprToString(expr: any, escape: ((arg: string) => string) | undefined): string {
   let result: string;
-  if (expr instanceof Array) {
+  if (typeof expr === "string") {
+    result = expr;
+  } else if (expr instanceof Array) {
     return expr.map((e) => templateLiteralExprToString(e, escape)).join(" ");
   } else if (expr instanceof CommandResult) {
     // remove last newline
     result = expr.stdout.replace(/\r?\n$/, "");
-  } else if (typeof expr === "string") {
-    result = expr;
   } else if (typeof expr === "object" && expr.toString === Object.prototype.toString) {
     throw new Error("Provided object does not override `toString()`.");
   } else {

--- a/src/command.ts
+++ b/src/command.ts
@@ -1423,6 +1423,10 @@ function templateLiteralExprToString(expr: any, escape: ((arg: string) => string
   } else if (expr instanceof CommandResult) {
     // remove last newline
     result = expr.stdout.replace(/\r?\n$/, "");
+  } else if (typeof expr === "string") {
+    result = expr;
+  } else if (typeof expr === "object" && expr.toString === Object.prototype.toString) {
+    throw new Error("Provided object does not override `toString()`.");
   } else {
     result = `${expr}`;
   }


### PR DESCRIPTION
Previously this would just become `[object Object]`.

```ts
const obj1 = {};
assertThrows(
  () => $`echo ${obj1}`,
  Error,
  "Failed resolving expression in command. Provided object does not override `toString()`.",
);
```