### PR TITLE
feat: support subshells

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1169,10 +1169,9 @@ Deno.test("subshells", async () => {
     assertEquals(result, "1\n2\n5\n");
   }
   await withTempDir(async (tempDir) => {
-    tempDir = tempDir.resolve();
     const subDir = tempDir.join("subDir");
     subDir.mkdirSync();
-    const result = await $`(cd subDir && pwd) && pwd`.text();
+    const result = await $`(cd subDir && pwd) && pwd`.cwd(tempDir).text();
     assertEquals(result, `${subDir}\n${tempDir}`);
   });
 });

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1169,6 +1169,7 @@ Deno.test("subshells", async () => {
     assertEquals(result, "1\n2\n5\n");
   }
   await withTempDir(async (tempDir) => {
+    tempDir = tempDir.resolve();
     const subDir = tempDir.join("subDir");
     subDir.mkdirSync();
     const result = await $`(cd subDir && pwd) && pwd`.text();

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1151,11 +1151,11 @@ Deno.test("subshells", async () => {
   }
   // exiting shouldn't exit the parent
   {
-    const result = await $`echo 1 && (echo 2 && exit 0 && echo 3) && echo 4`.noThrow().text();
+    const result = await $`echo 1 && (echo 2 && exit 0 && echo 3) && echo 4`.text();
     assertEquals(result, "1\n2\n4");
   }
   {
-    const result = await $`echo 1 && (echo 2 && exit 1 && echo 3) || echo 4`.noThrow().text();
+    const result = await $`echo 1 && (echo 2 && exit 1 && echo 3) || echo 4`.text();
     assertEquals(result, "1\n2\n4");
   }
   // shouldn't change the environment either

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1160,9 +1160,20 @@ Deno.test("subshells", async () => {
   }
   // shouldn't change the environment either
   {
+    assertEquals(await $`export VAR=5 && echo $VAR`.text(), "5"); // for reference
+    const result = await $`(export VAR=5) && echo $VAR`.text();
+    assertEquals(result, "");
+  }
+  {
     const result = await $`echo 1 && (echo 2 && export VAR=5 && echo $VAR) && echo $VAR`.text();
     assertEquals(result, "1\n2\n5\n");
   }
+  await withTempDir(async (tempDir) => {
+    const subDir = tempDir.join("subDir");
+    subDir.mkdirSync();
+    const result = await $`(cd subDir && pwd) && pwd`.text();
+    assertEquals(result, `${subDir}\n${tempDir}`);
+  });
 });
 
 Deno.test("output redirects", async () => {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1017,7 +1017,7 @@ async function executeCommandArgs(commandArgs: string[], context: Context): Prom
 async function executeSubshell(subshell: Subshell, context: Context): Promise<ExecuteResult> {
   const result = await executeSequentialList(subshell, context);
   // sub shells do not change the environment or cause an exit
-  return { code: result.code, changes: [] };
+  return { code: result.code };
 }
 
 async function pipeReaderToWritable(reader: Reader, writable: WritableStream<Uint8Array>, signal: AbortSignal) {


### PR DESCRIPTION
```ts
{
  const result = await $`(echo 1 && echo 2) | cat -`.text();
  assertEquals(result, "1\n2");
}
{
  const result = await $`echo 1 && (echo 2 && exit 1 && echo 3) || echo 4`.text();
  assertEquals(result, "1\n2\n4");
}
```