### PR TITLE
feat(BREAKING): a timed out `$.request` now throws a `TimeoutError` with a stack

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -39,6 +39,7 @@ import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { createPathRef, PathRef } from "./src/path.ts";
 
 export type { Delay, DelayIterator } from "./src/common.ts";
+export { TimeoutError } from "./src/common.ts";
 export { FsFileWrapper, PathRef } from "./src/path.ts";
 export type { ExpandGlobOptions, PathSymlinkOptions, SymlinkOptions, WalkEntry, WalkOptions } from "./src/path.ts";
 export {

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,6 +35,17 @@ export const symbols = {
   readable: Symbol.for("dax.readableStream"),
 };
 
+/** A timeout error. */
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+
+  get name() {
+    return "TimeoutError";
+  }
+}
+
 /**
  * Delay used for certain actions.
  *

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -294,7 +294,7 @@ Deno.test("$.request", (t) => {
         caughtErr = err;
       }
       assertEquals(caughtErr!, new TimeoutError("Request timed out after 100 milliseconds."));
-      assert(caughtErr!.stack!.includes("request.test.ts"));
+      assert(caughtErr!.stack!.includes("request.test.ts")); // current file
     });
 
     step("ability to abort while waiting", async () => {

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -2,6 +2,8 @@ import { Buffer, path } from "./deps.ts";
 import { assertEquals, assertRejects, toWritableStream } from "./deps.test.ts";
 import { RequestBuilder } from "./request.ts";
 import $ from "../mod.ts";
+import { TimeoutError } from "./common.ts";
+import { assert } from "./deps.test.ts";
 
 function withServer(action: (serverUrl: URL) => Promise<void>) {
   return new Promise<void>((resolve, reject) => {
@@ -282,16 +284,17 @@ Deno.test("$.request", (t) => {
     step("ensure times out waiting for body", async () => {
       const request = new RequestBuilder()
         .url(new URL("/sleep-body/10000", serverUrl))
-        .timeout(50)
+        .timeout(100)
         .showProgress();
       const response = await request.fetch();
-      let caughtErr: unknown;
+      let caughtErr: TimeoutError | undefined;
       try {
         await response.text();
       } catch (err) {
         caughtErr = err;
       }
-      assertEquals(caughtErr, "Request timed out after 50 milliseconds.");
+      assertEquals(caughtErr!, new TimeoutError("Request timed out after 100 milliseconds."));
+      assert(caughtErr!.stack!.includes("request.test.ts"));
     });
 
     step("ability to abort while waiting", async () => {


### PR DESCRIPTION
Previously it was throwing a string.