### PR TITLE
feat: rename `PathRef` to `Path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import $ from "https://deno.land/x/dax/mod.ts";
 // run a command
 await $`echo 5`; // outputs: 5
 
-// outputting 1 to stdout and running a sub process
+// outputting to stdout and running a sub process
 await $`echo 1 && deno run main.ts`;
 
 // parallel

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ await $`echo 1 && (echo 2 > ${buffer}) && echo 3`; // 1\n3\n
 console.log(buffer); // Uint8Array(2) [ 50, 10 ] (2\n)
 ```
 
-Supported objects: `Uint8Array`, `PathRef`, `WritableStream`, function that returns a `WritableStream`, any object that implements `[$.symbols.writable](): WritableStream`
+Supported objects: `Uint8Array`, `Path`, `WritableStream`, function that returns a `WritableStream`, any object that implements `[$.symbols.writable](): WritableStream`
 
 Or input redirects:
 
@@ -208,7 +208,7 @@ const request = $.request("https://plugins.dprint.dev/info.json")
 const bytes = await $`sleep 5 && gzip < ${request}`.bytes();
 ```
 
-Supported objects: `string`, `Uint8Array`, `PathRef`, `RequestBuilder`, `ReadableStream`, function that returns a `ReadableStream`, any object that implements `[$.symbols.readable](): ReadableStream`
+Supported objects: `string`, `Uint8Array`, `Path`, `RequestBuilder`, `ReadableStream`, function that returns a `ReadableStream`, any object that implements `[$.symbols.readable](): ReadableStream`
 
 ### Providing stdin
 
@@ -573,10 +573,10 @@ pb.with(() => {
 
 ## Path API
 
-The path API offers an immutable [`PathRef`](https://deno.land/x/dax/src/path.ts?s=PathRef) class, which is a similar concept to Rust's `PathBuf` struct.
+The path API offers an immutable [`Path`](https://deno.land/x/dax/src/path.ts?s=Path) class, which is a similar concept to Rust's `PathBuf` struct.
 
 ```ts
-// create a `PathRef`
+// create a `Path`
 let srcDir = $.path("src");
 // get information about the path
 srcDir.isDirSync(); // false
@@ -610,7 +610,7 @@ const srcDir = $.path("src").resolve();
 await $`echo ${srcDir}`;
 ```
 
-`PathRef`s can be created in the following ways:
+`Path`s can be created in the following ways:
 
 ```ts
 const pathRelative = $.path("./relative");
@@ -620,7 +620,7 @@ const pathStringFileUrl = $.path("file:///tmp"); // converts to /tmp
 const pathImportMeta = $.path(import.meta); // the path for the current module
 ```
 
-There are a lot of helper methods here, so check the [documentation on PathRef](https://deno.land/x/dax/src/path.ts?s=PathRef) for more details.
+There are a lot of helper methods here, so check the [documentation on Path](https://deno.land/x/dax/src/path.ts?s=Path) for more details.
 
 ## Helper functions
 

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,5 +1,14 @@
 import { readAll, readerFromStreamReader } from "./src/deps.ts";
-import $, { build$, CommandBuilder, CommandContext, CommandHandler, KillSignal, KillSignalController } from "./mod.ts";
+import $, {
+  build$,
+  CommandBuilder,
+  CommandContext,
+  CommandHandler,
+  KillSignal,
+  KillSignalController,
+  Path,
+  PathRef,
+} from "./mod.ts";
 import {
   assert,
   assertEquals,
@@ -810,7 +819,7 @@ Deno.test("piping to stdin", async (t) => {
     assertEquals(result, "1\n2");
   });
 
-  await t.step("PathRef", async () => {
+  await t.step("Path", async () => {
     await using tempDir = usingTempDir();
     const tempFile = tempDir.join("temp_file.txt");
     const fileText = "1 testing this out\n".repeat(1_000);
@@ -2097,6 +2106,12 @@ Deno.test("ensure KillSignalController readme example works", async () => {
 Deno.test("should support empty quoted string", async () => {
   const output = await $`echo '' test ''`.text();
   assertEquals(output, " test ");
+});
+
+Deno.test("esnure deprecated PathRef export still works", () => {
+  const path = new PathRef("hello");
+  assert(path instanceof Path);
+  assert(path instanceof PathRef);
 });
 
 function ensurePromiseNotResolved(promise: Promise<unknown>) {

--- a/mod.ts
+++ b/mod.ts
@@ -36,11 +36,14 @@ import {
 import { colors, outdent, which, whichSync } from "./src/deps.ts";
 import { wasmInstance } from "./src/lib/mod.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
-import { createPathRef, PathRef } from "./src/path.ts";
+import { createPath, Path } from "./src/path.ts";
 
 export type { Delay, DelayIterator } from "./src/common.ts";
 export { TimeoutError } from "./src/common.ts";
-export { FsFileWrapper, PathRef } from "./src/path.ts";
+export { FsFileWrapper, Path } from "./src/path.ts";
+/** @deprecated Import `Path` instead. */
+const PathRef = Path;
+export { PathRef };
 export type { ExpandGlobOptions, PathSymlinkOptions, SymlinkOptions, WalkEntry, WalkOptions } from "./src/path.ts";
 export {
   CommandBuilder,
@@ -201,7 +204,7 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
     options?: Create$Options<TNewExtras>,
   ): $Type<Omit<TExtras, keyof TNewExtras> & TNewExtras>;
   /** Changes the directory of the current process. */
-  cd(path: string | URL | ImportMeta | PathRef): void;
+  cd(path: string | URL | ImportMeta | Path): void;
   /**
    * Escapes an argument for the shell when NOT using the template
    * literal.
@@ -259,9 +262,9 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
   /** Helper function for creating path references, which provide an easier way for
    * working with paths, directories, and files on the file system.
    *
-   * The function creates a new `PathRef` from a path or URL string, file URL, or for the current module.
+   * The function creates a new `Path` from a path or URL string, file URL, or for the current module.
    */
-  path: typeof createPathRef;
+  path: typeof createPath;
   /**
    * Logs with potential indentation (`$.logIndent`)
    * and output of commands or request responses.
@@ -541,11 +544,11 @@ async function withRetries<TReturn>(
   throw new Error(`Failed after ${opts.count} attempts.`);
 }
 
-function cd(path: string | URL | ImportMeta | PathRef) {
+function cd(path: string | URL | ImportMeta | Path) {
   if (typeof path === "string" || path instanceof URL) {
-    path = new PathRef(path);
-  } else if (!(path instanceof PathRef)) {
-    path = new PathRef(path satisfies ImportMeta).parentOrThrow();
+    path = new Path(path);
+  } else if (!(path instanceof Path)) {
+    path = new Path(path satisfies ImportMeta).parentOrThrow();
   }
   Deno.chdir(path.toString());
 }
@@ -581,7 +584,7 @@ function buildInitial$State<TExtras extends ExtrasObject>(
 }
 
 const helperObject = {
-  path: createPathRef,
+  path: createPath,
   cd,
   escapeArg,
   stripAnsi(text: string) {

--- a/src/deps.test.ts
+++ b/src/deps.test.ts
@@ -1,4 +1,4 @@
-import { createPathRef, PathRef } from "./path.ts";
+import { createPath, Path } from "./path.ts";
 
 export {
   assert,
@@ -16,16 +16,16 @@ export { isNode } from "https://deno.land/x/which_runtime@0.2.0/mod.ts";
  * Creates a temporary directory, changes the cwd to this directory,
  * then cleans up and restores the cwd when complete.
  */
-export async function withTempDir(action: (path: PathRef) => Promise<void> | void) {
+export async function withTempDir(action: (path: Path) => Promise<void> | void) {
   await using dirPath = usingTempDir();
-  await action(createPathRef(dirPath).resolve());
+  await action(createPath(dirPath).resolve());
 }
 
-export function usingTempDir(): PathRef & AsyncDisposable {
+export function usingTempDir(): Path & AsyncDisposable {
   const originalDirPath = Deno.cwd();
   const dirPath = Deno.makeTempDirSync();
   Deno.chdir(dirPath);
-  const pathRef = createPathRef(dirPath).resolve();
+  const pathRef = createPath(dirPath).resolve();
   (pathRef as any)[Symbol.asyncDispose] = async () => {
     try {
       await Deno.remove(dirPath, { recursive: true });
@@ -34,5 +34,5 @@ export function usingTempDir(): PathRef & AsyncDisposable {
     }
     Deno.chdir(originalDirPath);
   };
-  return pathRef as PathRef & AsyncDisposable;
+  return pathRef as Path & AsyncDisposable;
 }

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -1,4 +1,4 @@
-import { type FsFileWrapper, PathRef } from "./path.ts";
+import { type FsFileWrapper, Path } from "./path.ts";
 import { logger } from "./console/logger.ts";
 import { Buffer, writeAll, writeAllSync } from "./deps.ts";
 import type { RequestBuilder } from "./request.ts";
@@ -48,7 +48,7 @@ export type ShellPipeReaderKind =
   | Uint8Array
   | CommandBuilder
   | FsFileWrapper
-  | PathRef
+  | Path
   | RequestBuilder;
 /**
  * The behaviour to use for a shell pipe.
@@ -65,7 +65,7 @@ export type ShellPipeWriterKind =
   | WriterSync
   | WritableStream<Uint8Array>
   | FsFileWrapper
-  | PathRef;
+  | Path;
 
 export class NullPipeReader implements Reader {
   read(_p: Uint8Array): Promise<number | null> {

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,7 +2,7 @@ import { formatMillis, symbols } from "./common.ts";
 import { TimeoutError } from "./common.ts";
 import { Delay, delayToMs, filterEmptyRecordValues, getFileNameFromUrl } from "./common.ts";
 import { ProgressBar } from "./console/mod.ts";
-import { PathRef } from "./path.ts";
+import { Path } from "./path.ts";
 
 interface RequestBuilderState {
   noThrow: boolean | number[];
@@ -342,7 +342,7 @@ export class RequestBuilder implements PromiseLike<RequestResponse> {
    *
    * @returns The path reference of the downloaded file.
    */
-  async pipeToPath(options?: Deno.WriteFileOptions): Promise<PathRef>;
+  async pipeToPath(options?: Deno.WriteFileOptions): Promise<Path>;
   /**
    * Pipes the response body to a file.
    *
@@ -352,11 +352,11 @@ export class RequestBuilder implements PromiseLike<RequestResponse> {
    * @returns The path reference of the downloaded file.
    */
   async pipeToPath(
-    path?: string | URL | PathRef | undefined,
+    path?: string | URL | Path | undefined,
     options?: Deno.WriteFileOptions,
-  ): Promise<PathRef>;
+  ): Promise<Path>;
   async pipeToPath(
-    filePathOrOptions?: string | URL | PathRef | Deno.WriteFileOptions,
+    filePathOrOptions?: string | URL | Path | Deno.WriteFileOptions,
     maybeOptions?: Deno.WriteFileOptions,
   ) {
     // Do not derive from the response url because that could cause the server
@@ -597,7 +597,7 @@ export class RequestResponse {
    *
    * @returns The path reference of the downloaded file
    */
-  async pipeToPath(options?: Deno.WriteFileOptions): Promise<PathRef>;
+  async pipeToPath(options?: Deno.WriteFileOptions): Promise<Path>;
   /**
    * Pipes the response body to a file.
    *
@@ -610,11 +610,11 @@ export class RequestResponse {
    * @returns The path reference of the downloaded file
    */
   async pipeToPath(
-    path?: string | URL | PathRef | undefined,
+    path?: string | URL | Path | undefined,
     options?: Deno.WriteFileOptions,
-  ): Promise<PathRef>;
+  ): Promise<Path>;
   async pipeToPath(
-    filePathOrOptions?: string | URL | PathRef | Deno.WriteFileOptions,
+    filePathOrOptions?: string | URL | Path | Deno.WriteFileOptions,
     maybeOptions?: Deno.WriteFileOptions,
   ) {
     // resolve the file path using the original url because it would be a security issue
@@ -763,16 +763,16 @@ export async function makeRequest(state: RequestBuilderState) {
 }
 
 function resolvePipeToPathParams(
-  pathOrOptions: string | URL | PathRef | Deno.WriteFileOptions | undefined,
+  pathOrOptions: string | URL | Path | Deno.WriteFileOptions | undefined,
   maybeOptions: Deno.WriteFileOptions | undefined,
   originalUrl: string | URL | undefined,
 ) {
-  let filePath: PathRef | undefined;
+  let filePath: Path | undefined;
   let options: Deno.WriteFileOptions | undefined;
   if (typeof pathOrOptions === "string" || pathOrOptions instanceof URL) {
-    filePath = new PathRef(pathOrOptions).resolve();
+    filePath = new Path(pathOrOptions).resolve();
     options = maybeOptions;
-  } else if (pathOrOptions instanceof PathRef) {
+  } else if (pathOrOptions instanceof Path) {
     filePath = pathOrOptions.resolve();
     options = maybeOptions;
   } else if (typeof pathOrOptions === "object") {
@@ -781,7 +781,7 @@ function resolvePipeToPathParams(
     options = maybeOptions;
   }
   if (filePath === undefined) {
-    filePath = new PathRef(getFileNameFromUrlOrThrow(originalUrl));
+    filePath = new Path(getFileNameFromUrlOrThrow(originalUrl));
   } else if (filePath.isDirSync()) {
     filePath = filePath.join(getFileNameFromUrlOrThrow(originalUrl));
   }


### PR DESCRIPTION
`PathRef` is still an export for the time being.

Closes https://github.com/dsherret/dax/issues/235