### PR TITLE
fix: better error message when providing a command builder to an expr

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -2108,10 +2108,22 @@ Deno.test("should support empty quoted string", async () => {
   assertEquals(output, " test ");
 });
 
-Deno.test("esnure deprecated PathRef export still works", () => {
+Deno.test("ensure deprecated PathRef export still works", () => {
   const path = new PathRef("hello");
   assert(path instanceof Path);
   assert(path instanceof PathRef);
+});
+
+Deno.test("nice error message when not awaiting a CommandBuilder", async () => {
+  await assertRejects(
+    async () => {
+      const cmd = $`echo 1`;
+      return await $`echo ${cmd}`;
+    },
+    Error,
+    "Providing a command builder is not yet supported (https://github.com/dsherret/dax/issues/239). " +
+      "Await the command builder's text before using it in an expression (ex. await $`cmd`.text()).",
+  );
 });
 
 function ensurePromiseNotResolved(promise: Promise<unknown>) {

--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import {
   CommandBuilder,
   escapeArg,
   getRegisteredCommandNamesSymbol,
-  setCommandTextAndFdsSymbol,
+  setCommandTextStateSymbol,
   template,
   templateRaw,
 } from "./src/command.ts";
@@ -632,8 +632,8 @@ function build$FromState<TExtras extends ExtrasObject = {}>(state: $State<TExtra
   };
   const result = Object.assign(
     (strings: TemplateStringsArray, ...exprs: any[]) => {
-      const { text, streams } = template(strings, exprs);
-      return state.commandBuilder.getValue()[setCommandTextAndFdsSymbol](text, streams);
+      const textState = template(strings, exprs);
+      return state.commandBuilder.getValue()[setCommandTextStateSymbol](textState);
     },
     helperObject,
     logDepthObj,
@@ -764,8 +764,8 @@ function build$FromState<TExtras extends ExtrasObject = {}>(state: $State<TExtra
         return state.requestBuilder.url(url);
       },
       raw(strings: TemplateStringsArray, ...exprs: any[]) {
-        const { text, streams } = templateRaw(strings, exprs);
-        return state.commandBuilder.getValue()[setCommandTextAndFdsSymbol](text, streams);
+        const textState = templateRaw(strings, exprs);
+        return state.commandBuilder.getValue()[setCommandTextStateSymbol](textState);
       },
       withRetries<TReturn>(opts: RetryOptions<TReturn>): Promise<TReturn> {
         return withRetries(result, state.errorLogger.getValue(), opts);


### PR DESCRIPTION
This is not yet supported. It needs to be awaited:

```ts
const cmd = $`echo 1`;  // should be: const cmd = await $`echo 1`.text();
await $`echo ${cmd}`;
```