### PR TITLE
feat: enable text, lines, and json to pull from stderr or combined buffers

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -240,6 +240,11 @@ Deno.test("CommandBuilder#json()", async () => {
   assertEquals(output, { test: 5 });
 });
 
+Deno.test("CommandBuilder#json('stderr')", async () => {
+  const output = await $`deno eval "console.error(JSON.stringify({ test: 5 }));"`.json("stderr");
+  assertEquals(output, { test: 5 });
+});
+
 Deno.test("stderrJson", async () => {
   const output = await $`deno eval "console.error(JSON.stringify({ test: 5 }));"`.stderr("piped");
   assertEquals(output.stderrJson, { test: 5 });
@@ -1101,6 +1106,16 @@ Deno.test("command args", async () => {
 
 Deno.test("command .lines()", async () => {
   const result = await $`echo 1 && echo 2`.lines();
+  assertEquals(result, ["1", "2"]);
+});
+
+Deno.test("command .lines('stderr')", async () => {
+  const result = await $`deno eval "console.error(1); console.error(2)"`.lines("stderr");
+  assertEquals(result, ["1", "2"]);
+});
+
+Deno.test("command .lines('combined')", async () => {
+  const result = await $`deno eval "console.log(1); console.error(2)"`.lines("combined");
   assertEquals(result, ["1", "2"]);
 });
 


### PR DESCRIPTION
There's been a few times where I've needed to grab info from stderr and the ergonomics of doing so are much worse than stdout given the lack of helpers for it. I've updated some of the original helpers for stdout to also optionally be used for stderr or both streams combined. 

There's probably a few more tests to write here and I may have missed something. 

Let me know what you think!