### PR TITLE
feat: add cross-platform `which` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dax
 
 [![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/dax/mod.ts)
-[![NPM Version](https://img.shields.io/npm/v/dax-sh.svg?style=flat)](http://www.npmjs.com/package/dax-sh)
+[![npm Version](https://img.shields.io/npm/v/dax-sh.svg?style=flat)](http://www.npmjs.com/package/dax-sh)
 
 <img src="src/assets/logo.svg" height="150px" alt="dax logo">
 
@@ -852,6 +852,7 @@ Currently implemented (though not every option is supported):
 - [`unset`](https://man7.org/linux/man-pages/man1/unset.1p.html) - Unsets an environment variable.
 - [`cat`](https://man7.org/linux/man-pages/man1/cat.1.html) - Concatenate files and print on the standard output
 - [`printenv`](https://man7.org/linux/man-pages/man1/printenv.1.html) - Print all or part of environment
+- `which` - Resolves the path to an executable (`-a` flag is not supported at this time)
 - More to come. Will try to get a similar list as https://deno.land/manual/tools/task_runner#built-in-commands
 
 You can also register your own commands with the shell parser (see below).

--- a/src/command.ts
+++ b/src/command.ts
@@ -35,6 +35,7 @@ import { Path } from "./path.ts";
 import { RequestBuilder } from "./request.ts";
 import { StreamFds } from "./shell.ts";
 import { symbols } from "./common.ts";
+import { whichCommand } from "./commands/which.ts";
 
 type BufferStdio = "inherit" | "null" | "streamed" | Buffer;
 
@@ -98,6 +99,7 @@ const builtInCommands = {
   pwd: pwdCommand,
   touch: touchCommand,
   unset: unsetCommand,
+  which: whichCommand,
 };
 
 /** @internal */

--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -1,0 +1,71 @@
+import { CommandContext } from "../command_handler.ts";
+import { errorToString } from "../common.ts";
+import { ExecuteResult } from "../result.ts";
+import { whichFromContext } from "../shell.ts";
+import { ArgKind, parseArgKinds } from "./args.ts";
+
+export async function whichCommand(
+  context: CommandContext,
+): Promise<ExecuteResult> {
+  try {
+    return await executeWhich(context);
+  } catch (err) {
+    return context.error(`which: ${errorToString(err)}`);
+  }
+}
+
+interface WhichFlags {
+  commandName: string | undefined;
+}
+
+async function executeWhich(context: CommandContext): Promise<ExecuteResult> {
+  let flags: WhichFlags;
+  try {
+    flags = parseArgs(context.args);
+  } catch (err) {
+    return await context.error(2, `which: ${errorToString(err)}`);
+  }
+  if (flags.commandName == null) {
+    return { code: 1 };
+  }
+  const path = await whichFromContext(flags.commandName, {
+    getVar(key) {
+      return context.env[key];
+    },
+  });
+  if (path != null) {
+    await context.stdout.writeLine(path);
+    return { code: 0 };
+  } else {
+    return { code: 1 };
+  }
+}
+
+export function parseArgs(args: string[]) {
+  let commandName: string | undefined;
+
+  for (const arg of parseArgKinds(args)) {
+    if (arg.kind === "Arg") {
+      if (commandName != null) {
+        throw Error("unsupported too many arguments");
+      }
+      commandName = arg.arg;
+    } else {
+      bailUnsupported(arg);
+    }
+  }
+  return {
+    commandName,
+  };
+}
+
+function bailUnsupported(arg: ArgKind): never {
+  switch (arg.kind) {
+    case "Arg":
+      throw Error(`unsupported argument: ${arg.arg}`);
+    case "ShortFlag":
+      throw Error(`unsupported flag: -${arg.arg}`);
+    case "LongFlag":
+      throw Error(`unsupported flag: --${arg.arg}`);
+  }
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1139,14 +1139,7 @@ async function resolveCommand(commandName: string, context: Context): Promise<Re
     };
   }
 
-  const realEnvironment = new DenoWhichRealEnvironment();
-  const commandPath = await which(commandName, {
-    os: Deno.build.os,
-    stat: realEnvironment.stat,
-    env(key) {
-      return context.getVar(key);
-    },
-  });
+  const commandPath = await whichFromContext(commandName, context);
   if (commandPath == null) {
     throw new Error(`Command not found: ${commandName}`);
   }
@@ -1154,6 +1147,20 @@ async function resolveCommand(commandName: string, context: Context): Promise<Re
     kind: "path",
     path: commandPath,
   };
+}
+
+const realEnvironment = new DenoWhichRealEnvironment();
+
+export async function whichFromContext(commandName: string, context: {
+  getVar(key: string): string | undefined;
+}) {
+  return await which(commandName, {
+    os: Deno.build.os,
+    stat: realEnvironment.stat,
+    env(key) {
+      return context.getVar(key);
+    },
+  });
 }
 
 async function executePipeSequence(sequence: PipeSequence, context: Context): Promise<ExecuteResult> {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1179,7 +1179,7 @@ export async function whichFromContext(commandName: string, context: {
   getVar(key: string): string | undefined;
 }) {
   // always use the current executable for "deno"
-  if (name.toUpperCase() === "DENO") {
+  if (commandName.toUpperCase() === "DENO") {
     return Deno.execPath();
   }
   return await which(commandName, {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1163,14 +1163,6 @@ async function resolveCommand(unresolvedCommand: UnresolvedCommand, context: Con
     }
   }
 
-  // always use the current executable for "deno"
-  if (unresolvedCommand.name.toUpperCase() === "DENO") {
-    return {
-      kind: "path",
-      path: Deno.execPath(),
-    };
-  }
-
   const commandPath = await whichFromContext(unresolvedCommand.name, context);
   if (commandPath == null) {
     throw new Error(`Command not found: ${unresolvedCommand.name}`);
@@ -1186,6 +1178,10 @@ const realEnvironment = new DenoWhichRealEnvironment();
 export async function whichFromContext(commandName: string, context: {
   getVar(key: string): string | undefined;
 }) {
+  // always use the current executable for "deno"
+  if (name.toUpperCase() === "DENO") {
+    return Deno.execPath();
+  }
   return await which(commandName, {
     os: Deno.build.os,
     stat: realEnvironment.stat,


### PR DESCRIPTION
I need this for verifying the shell is resolving the path to an excutable as I expect.