### PR TITLE
feat: add `TemplateExpr` type

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -218,7 +218,7 @@ Deno.test("throws when providing an object that doesn't override toString", asyn
   }
   class Test {
     toString() {
-      return 1;
+      return "1";
     }
   }
   {
@@ -2215,6 +2215,13 @@ Deno.test("which uses same as $.which", async () => {
     assertEquals(whichShellOutput.stdout, "");
     assertEquals(whichShellOutput.code, 2);
   }
+});
+
+Deno.test("expect error undefined", async () => {
+  await assertRejects(async () => {
+    // @ts-expect-error undefined not assignable
+    await $`echo ${undefined}`;
+  });
 });
 
 function ensurePromiseNotResolved(promise: Promise<unknown>) {

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -2222,6 +2222,10 @@ Deno.test("expect error undefined", async () => {
     // @ts-expect-error undefined not assignable
     await $`echo ${undefined}`;
   });
+  await assertRejects(async () => {
+    // @ts-expect-error null not assignable
+    await $`echo ${null}`;
+  });
 });
 
 function ensurePromiseNotResolved(promise: Promise<unknown>) {

--- a/mod.ts
+++ b/mod.ts
@@ -37,6 +37,7 @@ import { colors, outdent, which, whichSync } from "./src/deps.ts";
 import { wasmInstance } from "./src/lib/mod.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { createPath, Path } from "./src/path.ts";
+import { TemplateExpr } from "./src/command.ts";
 
 export type { Delay, DelayIterator } from "./src/common.ts";
 export { TimeoutError } from "./src/common.ts";
@@ -52,6 +53,7 @@ export {
   KillSignal,
   KillSignalController,
   type KillSignalListener,
+  type TemplateExpr,
 } from "./src/command.ts";
 export type { CommandContext, CommandHandler, CommandPipeReader, CommandPipeWriter } from "./src/command_handler.ts";
 export type { Closer, Reader, ShellPipeReaderKind, ShellPipeWriterKind, WriterSync } from "./src/pipes.ts";
@@ -126,7 +128,7 @@ export type $Type<TExtras extends ExtrasObject = {}> =
 
 /** String literal template. */
 export interface $Template {
-  (strings: TemplateStringsArray, ...exprs: any[]): CommandBuilder;
+  (strings: TemplateStringsArray, ...exprs: TemplateExpr[]): CommandBuilder;
 }
 
 /**
@@ -499,7 +501,7 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    * await $`command ${exprs}`;
    * ```
    */
-  raw(strings: TemplateStringsArray, ...exprs: any[]): CommandBuilder;
+  raw(strings: TemplateStringsArray, ...exprs: TemplateExpr[]): CommandBuilder;
   /**
    * Does the provided action until it succeeds (does not throw)
    * or the specified number of retries (`count`) is hit.
@@ -631,7 +633,7 @@ function build$FromState<TExtras extends ExtrasObject = {}>(state: $State<TExtra
     },
   };
   const result = Object.assign(
-    (strings: TemplateStringsArray, ...exprs: any[]) => {
+    (strings: TemplateStringsArray, ...exprs: TemplateExpr[]) => {
       const textState = template(strings, exprs);
       return state.commandBuilder.getValue()[setCommandTextStateSymbol](textState);
     },

--- a/src/command.ts
+++ b/src/command.ts
@@ -1279,6 +1279,9 @@ function templateInner(
     if (exprs.length > i) {
       try {
         const expr = exprs[i];
+        if (expr == null) {
+          throw "Expression was null or undefined.";
+        }
         const inputOrOutputRedirect = detectInputOrOutputRedirect(text);
         if (inputOrOutputRedirect === "<") {
           if (expr instanceof Path) {


### PR DESCRIPTION
Since dax accepts any object with a `toString()` method, that essentially means it accepts any object. So, this is essentially just a documentation change while also not allowing the `undefined` or `null` types.

Closes #254