### PR TITLE
chore: fix npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dax
 
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/dax/mod.ts)
+[![JSR](https://jsr.io/badges/@david/dax)](https://jsr.io/@david/dax)
 [![npm Version](https://img.shields.io/npm/v/dax-sh.svg?style=flat)](http://www.npmjs.com/package/dax-sh)
 
 <img src="src/assets/logo.svg" height="150px" alt="dax logo">

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@david/dax",
   "version": "0.0.0",
+  "nodeModulesDir": false,
   "tasks": {
     "test": "deno test -A",
     "wasmbuild": "deno run -A https://deno.land/x/wasmbuild@0.15.6/main.ts --sync --out ./src/lib"


### PR DESCRIPTION
It was creating node_modules directories in the npm folder because of the package.json (future versions of deno won't do this)