### PR TITLE
fix: regression - `.bytes()` signature should support no argument

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -152,6 +152,22 @@ Deno.test("should error setting stdout after getting combined output", () => {
   }
 });
 
+Deno.test("should get output as bytes", async () => {
+  {
+    const output = await $`echo 5 && deno eval 'console.error(1);'`.bytes();
+    assertEquals(new TextDecoder().decode(output), "5\n");
+  }
+  {
+    const output = await $`echo 5 && deno eval 'console.error(1);'`.bytes("combined");
+    assertEquals(new TextDecoder().decode(output), "5\n1\n");
+  }
+  {
+    const output = await $`echo 5 && deno eval 'console.error(1);'`.env("NOCOLOR", "1")
+      .bytes("stderr");
+    assertEquals(new TextDecoder().decode(output), "1\n");
+  }
+});
+
 Deno.test("should throw when exit code is non-zero", async () => {
   await assertRejects(
     async () => {

--- a/mod.ts
+++ b/mod.ts
@@ -47,7 +47,6 @@ export { FsFileWrapper, Path } from "./src/path.ts";
 /** @deprecated Import `Path` instead. */
 const PathRef = Path;
 // bug in deno: https://github.com/denoland/deno_lint/pull/1262
-// deno-lint-ignore verbatim-module-syntax
 export { PathRef };
 export {
   CommandBuilder,

--- a/src/command.ts
+++ b/src/command.ts
@@ -549,7 +549,7 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
    * const data = (await $`command`.quiet("stdout")).stdoutBytes;
    * ```
    */
-  async bytes(kind: StreamKind): Promise<Uint8Array> {
+  async bytes(kind: StreamKind = "stdout"): Promise<Uint8Array> {
     const command = kind === "combined" ? this.quiet(kind).captureCombined() : this.quiet(kind);
     return (await command)[`${kind}Bytes`];
   }

--- a/src/console/logger.ts
+++ b/src/console/logger.ts
@@ -49,5 +49,4 @@ const logger = {
   logAboveStaticText,
 };
 
-// deno-lint-ignore verbatim-module-syntax -- Bug https://github.com/denoland/deno_lint/pull/1262
 export { logger };


### PR DESCRIPTION
Considered a regression because the documentation had this called without an arg and this was unintended. Seems there was no tests for this method to catch this.