### PR TITLE
feat(windows): request folder permissions when traversing path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -39,7 +39,7 @@
     "@std/io": "jsr:@std/io@0.221.0",
     "@std/path": "jsr:@std/path@0.221.0",
     "@std/streams": "jsr:@std/streams@0.221.0",
-    "which": "jsr:@david/which@0.3",
+    "which": "jsr:@david/which@^0.4.1",
     "which_runtime": "jsr:@david/which-runtime@0.2"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,7 +3,7 @@
   "packages": {
     "specifiers": {
       "jsr:@david/which-runtime@0.2": "jsr:@david/which-runtime@0.2.0",
-      "jsr:@david/which@0.3": "jsr:@david/which@0.3.0",
+      "jsr:@david/which@^0.4.1": "jsr:@david/which@0.4.1",
       "jsr:@deno/cache-dir@^0.8.0": "jsr:@deno/cache-dir@0.8.0",
       "jsr:@deno/dnt@^0.41.1": "jsr:@deno/dnt@0.41.1",
       "jsr:@std/assert@^0.218.2": "jsr:@std/assert@0.218.2",
@@ -29,8 +29,8 @@
       "@david/which-runtime@0.2.0": {
         "integrity": "69c59142babcff447efff6a6460316131b702ce1713f9f5ddbbb909136d6d7cd"
       },
-      "@david/which@0.3.0": {
-        "integrity": "6bdb62c40ac90edcf328e854fa8103a8db21e7c326089cbe3c3a1cf7887d3204"
+      "@david/which@0.4.1": {
+        "integrity": "896a682b111f92ab866cc70c5b4afab2f5899d2f9bde31ed00203b9c250f225e"
       },
       "@deno/cache-dir@0.8.0": {
         "integrity": "e87e80a404958f6350d903e6238b72afb92468378b0b32111f7a1e4916ac7fe7",
@@ -385,7 +385,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@david/which-runtime@0.2",
-      "jsr:@david/which@0.3",
+      "jsr:@david/which@^0.4.1",
       "jsr:@deno/dnt@^0.41.1",
       "jsr:@std/assert@^0.221.0",
       "jsr:@std/fmt@^0.221.0",

--- a/dprint.json
+++ b/dprint.json
@@ -13,9 +13,8 @@
     "lineWidth": 120
   },
   "excludes": [
-    "**/node_modules",
-    "**/*-lock.json",
-    "**/target",
+    "target",
+    "npm",
     "**/*.generated.js"
   ],
   "plugins": [

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -714,7 +714,8 @@ Deno.test("env should be clean slate when clearEnv is set", async () => {
   }
   Deno.env.set("DAX_TVAR", "123");
   try {
-    const text = await $`deno eval 'console.log("DAX_TVAR: " + Deno.env.get("DAX_TVAR"))'`.clearEnv().text();
+    const text = await $`deno eval --no-config 'console.log("DAX_TVAR: " + Deno.env.get("DAX_TVAR"))'`.clearEnv()
+      .text();
     assertEquals(text, "DAX_TVAR: undefined");
   } finally {
     Deno.env.delete("DAX_TVAR");
@@ -725,7 +726,7 @@ Deno.test("clearEnv + exportEnv should not clear out real environment", async ()
   Deno.env.set("DAX_TVAR", "123");
   try {
     const text =
-      await $`deno eval 'console.log("VAR: " + Deno.env.get("DAX_TVAR") + " VAR2: " + Deno.env.get("DAX_TVAR2"))'`
+      await $`deno eval --no-config 'console.log("VAR: " + Deno.env.get("DAX_TVAR") + " VAR2: " + Deno.env.get("DAX_TVAR2"))'`
         .env("DAX_TVAR2", "shake it shake")
         .clearEnv()
         .exportEnv()

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
 import * as colors from "@std/fmt/colors";
-import { RealEnvironment, which, whichSync } from "which";
+import { which, whichSync } from "which";
 import {
   CommandBuilder,
   escapeArg,

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
 import * as colors from "@std/fmt/colors";
-import { which, whichSync } from "which";
+import { RealEnvironment, which, whichSync } from "which";
 import {
   CommandBuilder,
   escapeArg,
@@ -40,6 +40,7 @@ import { wasmInstance } from "./src/lib/mod.ts";
 import { createPath, Path } from "./src/path.ts";
 import { RequestBuilder, withProgressBarFactorySymbol } from "./src/request.ts";
 import { outdent } from "./src/vendor/outdent.ts";
+import { denoWhichRealEnv } from "./src/shell.ts";
 
 export type { Delay, DelayIterator } from "./src/common.ts";
 export { TimeoutError } from "./src/common.ts";
@@ -510,7 +511,7 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    * or the specified number of retries (`count`) is hit.
    */
   withRetries<TReturn>(opts: RetryOptions<TReturn>): Promise<TReturn>;
-  /** Re-export of `deno_which` for getting the path to an executable. */
+  /** Re-export of `jsr:@david/which` for getting the path to an executable. */
   which: Which;
   /** Similar to `which`, but synchronously. */
   whichSync: WhichSync;
@@ -601,14 +602,14 @@ const helperObject = {
     if (commandName.toUpperCase() === "DENO") {
       return Promise.resolve(Deno.execPath());
     } else {
-      return which(commandName);
+      return which(commandName, denoWhichRealEnv);
     }
   },
   whichSync(commandName: string) {
     if (commandName.toUpperCase() === "DENO") {
       return Deno.execPath();
     } else {
-      return whichSync(commandName);
+      return whichSync(commandName, denoWhichRealEnv);
     }
   },
 };

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1215,7 +1215,15 @@ async function resolveCommand(unresolvedCommand: UnresolvedCommand, context: Con
   };
 }
 
-const realEnvironment = new DenoWhichRealEnvironment();
+class WhichEnv extends DenoWhichRealEnvironment {
+  requestPermission(folderPath: string) {
+    Deno.permissions.requestSync({
+      name: "read",
+      path: folderPath,
+    });
+  }
+}
+export const denoWhichRealEnv = new WhichEnv();
 
 export async function whichFromContext(commandName: string, context: {
   getVar(key: string): string | undefined;
@@ -1226,10 +1234,11 @@ export async function whichFromContext(commandName: string, context: {
   }
   return await which(commandName, {
     os: Deno.build.os,
-    stat: realEnvironment.stat,
+    stat: denoWhichRealEnv.stat,
     env(key) {
       return context.getVar(key);
     },
+    requestPermission: denoWhichRealEnv.requestPermission,
   });
 }
 


### PR DESCRIPTION
```
> deno run asdf.ts
✅ Granted env access.                                                                                                                                                                                                                                                                          
✅ Granted read access to <CWD>.                                                                                                                                                                                                                                                                
✅ Granted read access to "C:\Program Files\PowerShell\7\".                                                                                                                                                                                                                                     
✅ Granted read access to "C:\Program Files\Common Files\Oracle\Java\javapath\".                                                                                                                                                                                                                
✅ Granted read access to "C:\PROGRAMDATA\ORACLE\JAVA\JAVAPATH\".                                                                                                                                                                                                                               
✅ Granted read access to "C:\WINDOWS\SYSTEM32\".                                                                                                                                                                                                                                               
✅ Granted run access to "C:\WINDOWS\SYSTEM32\curl.EXE".
```

Closes https://github.com/dsherret/dax/issues/183