### PR TITLE
docs: fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Deno:
 
 ```sh
 # or skip and import directly from `jsr:@david/dax@<version>`
-deno add @david/dax
+deno add jsr:@david/dax
 ```
 
 Node:


### PR DESCRIPTION
After Deno v2.0.0, `deno add @scope/name` can't work well, the prefix is needed.
So I fixed it.
https://docs.deno.com/runtime/reference/cli/add/