### PR TITLE
fix(BREAKING): remove confusing `$.cd` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,17 +663,6 @@ There are a lot of helper methods here, so check the [documentation on Path](htt
 
 ## Helper functions
 
-Changing the current working directory of the current process:
-
-```ts
-$.cd("someDir");
-console.log(Deno.cwd()); // will be in someDir directory
-
-// or change the directory of the process to be in
-// the directory of the current script
-$.cd(import.meta);
-```
-
 Sleeping asynchronously for a specified amount of time:
 
 ```ts

--- a/deno.lock
+++ b/deno.lock
@@ -7,6 +7,7 @@
     "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
+    "jsr:@deno/graph@~0.73.1": "0.73.1",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@1": "1.0.8",
@@ -49,6 +50,7 @@
     "@deno/cache-dir@0.10.3": {
       "integrity": "eb022f84ecc49c91d9d98131c6e6b118ff63a29e343624d058646b9d50404776",
       "dependencies": [
+        "jsr:@deno/graph",
         "jsr:@std/fmt@0.223",
         "jsr:@std/fs@0.223",
         "jsr:@std/io@0.223",
@@ -65,6 +67,9 @@
         "jsr:@std/path@1",
         "jsr:@ts-morph/bootstrap"
       ]
+    },
+    "@deno/graph@0.73.1": {
+      "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1972,27 +1972,6 @@ Deno.test("touch test", async () => {
   });
 });
 
-Deno.test("cd", () => {
-  const cwd = Deno.cwd();
-
-  try {
-    $.cd("./src");
-    assert(Deno.cwd().endsWith("src"));
-    // todo: this originally passed in import.meta, but that
-    // didn't work in the node cjs tests, so now it's doing this
-    // thing that doesn't really test it
-    $.cd($.path(new URL(import.meta.url)).parentOrThrow());
-    $.cd("./src");
-    assert(Deno.cwd().endsWith("src"));
-    const path = $.path(import.meta.url).parentOrThrow();
-    $.cd(path);
-    $.cd("./src");
-    assert(Deno.cwd().endsWith("src"));
-  } finally {
-    Deno.chdir(cwd);
-  }
-});
-
 Deno.test("cat", async () => {
   await withTempDir(async (tempDir) => {
     await Deno.writeTextFile("hello", "hello world");

--- a/mod.ts
+++ b/mod.ts
@@ -209,8 +209,6 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
   build$<TNewExtras extends ExtrasObject = {}>(
     options?: Create$Options<TNewExtras>,
   ): $Type<Omit<TExtras, keyof TNewExtras> & TNewExtras>;
-  /** Changes the directory of the current process. */
-  cd(path: string | URL | ImportMeta | Path): void;
   /**
    * Escapes an argument for the shell when NOT using the template
    * literal.

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -2,7 +2,7 @@ import { build, emptyDir } from "@deno/dnt";
 import { walkSync } from "@std/fs/walk";
 import $ from "../mod.ts";
 
-$.cd($.path(import.meta.url).parentOrThrow().parentOrThrow());
+Deno.chdir($.path(import.meta.url).parentOrThrow().parentOrThrow().toString());
 
 await emptyDir("./npm");
 
@@ -66,7 +66,7 @@ await build({
     }],
   },
   filterDiagnostic(diagnostic) {
-    return !diagnostic.file?.fileName.includes("@david/path/0.2.0/mod.ts") ?? true;
+    return !diagnostic.file?.fileName.includes("@david/path/0.2.0/mod.ts");
   },
   compilerOptions: {
     stripInternal: false,


### PR DESCRIPTION
The `$.cd` helper is confusing because it changes the current directory of the process. It's trivial to just call `Deno.chdir` or `process.chdir` instead and nowadays there is `process.chdir(import.meta.dirname)` when wanting to switch the process' cwd to the current script's (previous it was verbose).

https://github.com/dsherret/dax/issues/298