### PR TITLE
feat: add `$.rawArg` for not escaping a specific argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,21 @@ const dirNames = ["some_dir", "other dir"];
 await $`mkdir ${dirNames}`; // executes as: mkdir some_dir 'other dir'
 ```
 
-If you do not want to escape arguments in a template literal, you can opt out completely, by using `$.raw`:
+If you do not want to escape an argument in a template literal, you can opt out by using `$.rawArg` starting in 0.43.0:
 
 ```ts
-const args = "arg1   arg2   arg3";
-await $.raw`echo ${args}`; // executes as: echo arg1   arg2   arg3
+const args = "arg1   arg2";
+await $`echo ${$.rawArg(args)} ${args}`; // executes as: echo arg1 arg2 arg1   arg2
+```
+
+Alternatively, you can opt out completely by using `$.raw`:
+
+```ts
+const args = "arg1   arg2";
+await $.raw`echo ${args}`; // executes as: echo arg1 arg2
 
 // or escape a specific argument while using $.raw
-const args2 = "arg1  arg2";
-await $.raw`echo ${$.escapeArg(args2)} ${args2}`; // executes as: echo "arg1  arg2" arg1  arg2
+await $.raw`echo ${$.escapeArg(args)} ${args}`; // executes as: echo "arg1  arg2" arg1 arg2
 ```
 
 Providing stdout of one command to another is possible as follows:

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -339,6 +339,11 @@ Deno.test("raw should handle command result", async () => {
   assertEquals(text, `[ "1", "2", "3" ]`);
 });
 
+Deno.test("rawArg should handle arguments", async () => {
+  const text = await $`echo ${$.rawArg("1   2   3")}`.text();
+  assertEquals(text, `1 2 3`);
+});
+
 Deno.test("command builder should build", async () => {
   const commandBuilder = new CommandBuilder()
     .env("TEST", "123");

--- a/mod.ts
+++ b/mod.ts
@@ -4,11 +4,12 @@ import {
   CommandBuilder,
   escapeArg,
   getRegisteredCommandNamesSymbol,
+  rawArg,
   setCommandTextStateSymbol,
   template,
   templateRaw,
 } from "./src/command.ts";
-import type { TemplateExpr } from "./src/command.ts";
+import type { RawArg, TemplateExpr } from "./src/command.ts";
 import {
   Box,
   type Delay,
@@ -57,6 +58,7 @@ export {
   KillSignal,
   KillSignalController,
   type KillSignalListener,
+  RawArg,
   type TemplateExpr,
 } from "./src/command.ts";
 export type { CommandContext, CommandHandler, CommandPipeReader, CommandPipeWriter } from "./src/command_handler.ts";
@@ -505,6 +507,18 @@ export interface $BuiltInProperties<TExtras extends ExtrasObject = {}> {
    */
   raw(strings: TemplateStringsArray, ...exprs: TemplateExpr[]): CommandBuilder;
   /**
+   * Prevents an argument being escaped.
+   *
+   * ```ts
+   * import $ from "dax";
+   *
+   * const value = "1    2     3";
+   * await $`echo ${value}`; // 1    2     3
+   * await $`echo ${$.rawArg(value)}`; // 1 2 3
+   * ```
+   */
+  rawArg<T>(arg: T): RawArg<T>;
+  /**
    * Does the provided action until it succeeds (does not throw)
    * or the specified number of retries (`count`) is hit.
    */
@@ -771,6 +785,7 @@ function build$FromState<TExtras extends ExtrasObject = {}>(state: $State<TExtra
         const textState = templateRaw(strings, exprs);
         return state.commandBuilder.getValue()[setCommandTextStateSymbol](textState);
       },
+      rawArg,
       withRetries<TReturn>(opts: RetryOptions<TReturn>): Promise<TReturn> {
         return withRetries(result, state.errorLogger.getValue(), opts);
       },

--- a/src/command.ts
+++ b/src/command.ts
@@ -1119,6 +1119,22 @@ export function escapeArg(arg: string) {
   }
 }
 
+export class RawArg<T> {
+  #value: T;
+
+  constructor(value: T) {
+    this.#value = value;
+  }
+
+  get value(): T {
+    return this.#value;
+  }
+}
+
+export function rawArg<T>(arg: T): RawArg<T> {
+  return new RawArg(arg);
+}
+
 function validateCommandName(command: string) {
   if (command.match(/^[a-zA-Z0-9-_]+$/) == null) {
     throw new Error("Invalid command name");
@@ -1498,6 +1514,8 @@ function templateLiteralExprToString(expr: TemplateExpr, escape: ((arg: string) 
       "Providing a command builder is not yet supported (https://github.com/dsherret/dax/issues/239). " +
         "Await the command builder's text before using it in an expression (ex. await $`cmd`.text()).",
     );
+  } else if (expr instanceof RawArg) {
+    return templateLiteralExprToString(expr.value, undefined);
   } else if (typeof expr === "object" && expr.toString === Object.prototype.toString) {
     throw new Error("Provided object does not override `toString()`.");
   } else {


### PR DESCRIPTION
```ts
const args = "arg1   arg2";
await $`echo ${$.rawArg(args)} ${args}`; // executes as: echo arg1 arg2 arg1   arg2
```

Closes https://github.com/dsherret/dax/issues/284