### PR TITLE
fix(BREAKING): remove deno as a built-in command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: canary
 

--- a/README.md
+++ b/README.md
@@ -959,11 +959,12 @@ const result = await requestBuilder
 You may wish to create your own `$` function that has a certain setup context (for example, custom commands or functions on `$`, a defined environment variable or cwd). You may do this by using the exported `build$` with `CommandBuilder` and/or `RequestBuilder`, which is essentially what the main default exported `$` uses internally to build itself. In addition, you may also add your own functions to `$`:
 
 ```ts
-import { build$, CommandBuilder, RequestBuilder } from "@david/dax";
+import { build$, CommandBuilder, createExecutableCommand, RequestBuilder } from "@david/dax";
 
 // creates a $ object with the provided starting environment
 const $ = build$({
   commandBuilder: new CommandBuilder()
+    .registerCommand("deno", createExecutableCommand(Deno.execPath()))
     .cwd("./subDir")
     .env("HTTPS_PROXY", "some_value"),
   requestBuilder: new RequestBuilder()

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -18,6 +18,7 @@ import $, {
 } from "./mod.ts";
 import { setNotTtyForTesting } from "./src/console/utils.ts";
 import { usingTempDir, withTempDir } from "./src/with_temp_dir.ts";
+import { createExecutableCommand } from "./src/commands/executable.ts";
 
 // Deno will not be a tty because it captures the pipes, but Node
 // will be, so manually say that we're not a tty for testing so
@@ -727,7 +728,9 @@ Deno.test("env should be clean slate when clearEnv is set", async () => {
   }
   Deno.env.set("DAX_TVAR", "123");
   try {
-    const text = await $`deno eval --no-config 'console.log("DAX_TVAR: " + Deno.env.get("DAX_TVAR"))'`.clearEnv()
+    const text = await $`deno eval --no-config 'console.log("DAX_TVAR: " + Deno.env.get("DAX_TVAR"))'`
+      .clearEnv()
+      .registerCommand("deno", createExecutableCommand(Deno.execPath()))
       .text();
     assertEquals(text, "DAX_TVAR: undefined");
   } finally {
@@ -742,6 +745,7 @@ Deno.test("clearEnv + exportEnv should not clear out real environment", async ()
       await $`deno eval --no-config 'console.log("VAR: " + Deno.env.get("DAX_TVAR") + " VAR2: " + Deno.env.get("DAX_TVAR2"))'`
         .env("DAX_TVAR2", "shake it shake")
         .clearEnv()
+        .registerCommand("deno", createExecutableCommand(Deno.execPath()))
         .exportEnv()
         .text();
     assertEquals(text, "VAR: undefined VAR2: shake it shake");

--- a/mod.ts
+++ b/mod.ts
@@ -612,18 +612,10 @@ const helperObject = {
   dedent: outdent,
   sleep,
   which(commandName: string) {
-    if (commandName.toUpperCase() === "DENO") {
-      return Promise.resolve(Deno.execPath());
-    } else {
-      return which(commandName, denoWhichRealEnv);
-    }
+    return which(commandName, denoWhichRealEnv);
   },
   whichSync(commandName: string) {
-    if (commandName.toUpperCase() === "DENO") {
-      return Deno.execPath();
-    } else {
-      return whichSync(commandName, denoWhichRealEnv);
-    }
+    return whichSync(commandName, denoWhichRealEnv);
   },
 };
 

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -50,7 +50,11 @@ async function withServer(action: (serverUrl: URL) => Promise<void>) {
                 }
                 const abortListener = () => {
                   clearTimeout(timeoutId);
-                  controller.close();
+                  try {
+                    controller.close();
+                  } catch {
+                    // ignore
+                  }
                   resolve();
                   signal.removeEventListener("abort", abortListener);
                   abortController.signal.removeEventListener("abort", abortListener);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1078,10 +1078,6 @@ export const denoWhichRealEnv = new WhichEnv();
 export async function whichFromContext(commandName: string, context: {
   getVar(key: string): string | undefined;
 }) {
-  // always use the current executable for "deno"
-  if (commandName.toUpperCase() === "DENO") {
-    return Deno.execPath();
-  }
   return await which(commandName, {
     os: Deno.build.os,
     stat: denoWhichRealEnv.stat,


### PR DESCRIPTION
This removes `deno` always resolving to `Deno.execPath()`.

If you want the old behaviour, you can register "deno" as a custom command like so:

```ts
import { build$, CommandBuilder, createExecutableCommand } from "@david/dax";

const $ = build$({
  commandBuilder: new CommandBuilder()
    .registerCommand("deno", createExecutableCommand(Deno.execPath()))
});
```

Closes https://github.com/dsherret/dax/issues/308
Closes https://github.com/dsherret/dax/issues/297
Closes https://github.com/dsherret/dax/issues/255