### PR TITLE
fix: surface type checking error when erroneously providing a `Promise` in a template literal expr

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -2233,6 +2233,29 @@ Deno.test("nice error message when not awaiting a CommandBuilder", async () => {
   );
 });
 
+Deno.test("type error null", async () => {
+  await assertRejects(
+    async () => {
+      // @ts-expect-error promise is not supported here
+      return await $`echo ${null}`;
+    },
+    Error,
+    "Failed resolving expression in command. Expression was null or undefined.",
+  );
+});
+
+Deno.test("type error Promise", async () => {
+  await assertRejects(
+    async () => {
+      const promise = Promise.resolve("");
+      // @ts-expect-error promise is not supported here
+      return await $`echo ${promise}`;
+    },
+    Error,
+    "Failed resolving expression in command. Provided object was a Promise. Please await it before providing it.",
+  );
+});
+
 Deno.test("which uses same as $.which", async () => {
   {
     const whichFnOutput = await $.which("deno");

--- a/src/command.ts
+++ b/src/command.ts
@@ -1274,24 +1274,27 @@ export function templateRaw(strings: TemplateStringsArray, exprs: TemplateExpr[]
   return templateInner(strings, exprs, undefined);
 }
 
-export type TemplateExpr =
+type NonRedirectTemplateExpr =
   | string
   | number
   | boolean
   | Path
   | Uint8Array
   | CommandResult
-  | { toString(): string }
-  | (string | number | boolean | Path | { toString(): string })[]
+  | RawArg<NonRedirectTemplateExpr>
+  | { toString(): string };
+export type TemplateExpr =
+  | NonRedirectTemplateExpr
+  | NonRedirectTemplateExpr[]
   | ReadableStream<Uint8Array>
   | {
-    // type is unfortuantely not that great
+    // type is unfortunately not that great
     [readable: symbol]: () => ReadableStream<Uint8Array>;
   }
   | (() => ReadableStream<Uint8Array>)
   // for input redirects only
   | {
-    // type is unfortuantely not that great
+    // type is unfortunately not that great
     [writable: symbol]: () => WritableStream<Uint8Array>;
   }
   | WritableStream<Uint8Array>


### PR DESCRIPTION
There were some bugs caused in Deno's scripts because promises were provided.