### PR TITLE
feat: add combined output redirect support

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1375,6 +1375,26 @@ Deno.test("output redirects", async () => {
   });
 });
 
+Deno.test("output redirects with & (both stdout and stderr)", async () => {
+  await withTempDir(async (tempDir) => {
+    // Test that both streams really go to the same file
+    const tempFile = tempDir.join("combined.txt");
+    await $`deno eval 'console.log(1); console.error(2); console.log(3);' &> ./combined.txt`
+      .cwd(tempDir)
+      .env("NO_COLOR", "1");
+    const content4 = tempFile.readTextSync();
+    assertStringIncludes(content4, "1");
+    assertStringIncludes(content4, "2");
+    assertStringIncludes(content4, "3");
+
+    // Test with /dev/null
+    const result = await $`deno eval 'console.log("visible"); console.error("invisible");' &> /dev/null`
+      .env("NO_COLOR", "1")
+      .text();
+    assertEquals(result, "");
+  });
+});
+
 Deno.test("input redirects", async () => {
   await withTempDir(async (tempDir) => {
     tempDir.join("test.txt").writeTextSync("Hi!");

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -771,7 +771,7 @@ interface ResolvedRedirectPipeInput {
 interface ResolvedRedirectPipeOutput {
   kind: "output";
   pipe: PipeWriter;
-  toFd: 1 | 2;
+  toFd: 1 | 2 | "&";
 }
 
 async function resolveRedirectPipe(
@@ -915,7 +915,10 @@ function getStdinReader(stdin: CommandPipeReader): Reader {
   }
 }
 
-function resolveRedirectToFd(redirect: Redirect, context: Context): ExecuteResult | Promise<ExecuteResult> | 1 | 2 | "&" {
+function resolveRedirectToFd(
+  redirect: Redirect,
+  context: Context,
+): ExecuteResult | Promise<ExecuteResult> | 1 | 2 | "&" {
   const maybeFd = redirect.maybeFd;
   if (maybeFd == null) {
     return 1; // stdout


### PR DESCRIPTION
This seemed a little too easy. As far as I can tell with local CLI testing it works, but I'm curious if there is something obviously wrong with it.

Supported cases:

```sh
echo hi &>/dev/null
sh stdout_and_errer &>test.log
```