### PR TITLE
feat(BREAKING): add `questionGlob` option and match `?` as a literal by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ Note that these cross-platform commands can be bypassed by running them through 
 - `nullglob` (`shopt -s`/`-u`) - When enabled, a glob pattern matching nothing expands to nothing. Default: **off**
 - `failglob` (`shopt -s`/`-u`) - When enabled, a glob pattern matching nothing causes an error. Default: **off**
 - `globstar` (`shopt -s`/`-u`) - When enabled, `**` matches recursively across directories. Default: **on**
+- `questionGlob` (builder only) - When enabled, `?` matches any single character in glob patterns. When disabled, `?` is treated literally. Default: **off**
 
 These can be configured via builder methods or when building a custom `$`:
 
@@ -931,7 +932,8 @@ const $ = build$({
       .pipefail()
       .nullglob()
       .failglob()
-      .globstar(false),
+      .globstar(false)
+      .questionGlob(),
 });
 ```
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -672,6 +672,27 @@ export class CommandBuilder implements PromiseLike<CommandResult> {
   }
 
   /**
+   * Sets whether questionGlob is enabled. When enabled, `?` matches any
+   * single character in glob patterns. When disabled (the default), `?` is
+   * treated literally.
+   *
+   * This option is only available via the builder API, not via `shopt` or `set`.
+   *
+   * ```ts
+   * // without questionGlob (default): ? is literal
+   * await $`echo a?c`; // outputs "a?c"
+   *
+   * // with questionGlob: ? matches any single character
+   * await $`echo a?c`.questionGlob(); // matches files like "abc", "axc", etc.
+   * ```
+   */
+  questionGlob(value = true): CommandBuilder {
+    return this.#newWithState((state) => {
+      state.shellOptions.questionGlob = value;
+    });
+  }
+
+  /**
    * Sets the provided stream (stdout by default) as quiet, spawns the command, and gets the stream as a string without the last newline.
    * Can be used to get stdout, stderr, or both.
    *

--- a/src/result.ts
+++ b/src/result.ts
@@ -87,8 +87,9 @@ export interface CdChange {
  * - `failglob`: a glob pattern that matches no files causes an error
  * - `pipefail`: pipeline exit code is the rightmost non-zero exit code
  * - `globstar`: `**` matches recursively across directories (default)
+ * - `questionGlob`: `?` matches any single character in glob patterns
  */
-export type ShellOption = "nullglob" | "failglob" | "pipefail" | "globstar";
+export type ShellOption = "nullglob" | "failglob" | "pipefail" | "globstar" | "questionGlob";
 
 /** Change that sets a shell option (ex. `shopt -s nullglob` or `set -o pipefail`).
  *


### PR DESCRIPTION
This can be turned back on by using `.questionGlob()`

Closes https://github.com/dsherret/dax/issues/352