### PR TITLE
feat(BREAKING): update to jsr:@david/shell@0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,10 +978,6 @@ const $ = build$({
 });
 ```
 
-### Windows command resolution (PATHEXT)
-
-On Windows, path-like commands (for example, `./tool` or `../bin/tool`) are resolved against `PATHEXT`, so `./tool` will find `tool.exe`, `tool.bat`, etc., without you having to spell out the extension.
-
 ### Cross-platform shebang support
 
 Users on unix-based platforms often write a script like so:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ const result = await $`echo 1 && echo 2`.lines();
 console.log(result); // ["1", "2"]
 ```
 
+Stream the output line-by-line without buffering the whole thing into memory (makes the chosen stream "quiet"):
+
+```ts
+for await (const line of $`cat big.txt`.linesIter()) {
+  console.log(line);
+}
+
+// also works for stderr
+for await (const line of $`some-command`.linesIter("stderr")) {
+  console.log(line);
+}
+```
+
+Breaking out of the loop early kills the child process. Lines split at `\n` or `\r\n` and the terminators are not included.
+
 Get stderr's text:
 
 ```ts
@@ -825,6 +840,29 @@ Sequential lists:
 const result = await $`cd someDir ; deno eval 'console.log(Deno.cwd())'`;
 ```
 
+Multi-line commands — write each command on its own line:
+
+```ts
+await $`
+  echo one
+  echo two
+  echo three
+`;
+```
+
+In multi-line input, `errexit` (`set -e`) is on by default — the first failing line stops the rest. Single-line input (`a; b`) will continue-on-failure. You can opt in or out explicitly with `set -e` / `set +e`:
+
+```ts
+// keep running even if an earlier line fails
+await $`
+  set +e
+  (exit 3)
+  echo still-ran
+`;
+```
+
+Trailing `&&`, `||`, `|`, and backslash-newline continue onto the next line as you'd expect.
+
 Boolean lists:
 
 ```ts
@@ -919,6 +957,7 @@ Note that these cross-platform commands can be bypassed by running them through 
 
 ### Shell Options
 
+- `errexit` (`set -e`/`+e` or `set -o`/`+o errexit`) - When enabled, a sequential list aborts at the first non-zero command. Default: **on for multi-line input, off for single-line input**
 - `pipefail` (`set -o`/`+o`) - When enabled, a pipeline's exit code is the rightmost non-zero exit code. Default: **off**
 - `nullglob` (`shopt -s`/`-u`) - When enabled, a glob pattern matching nothing expands to nothing. Default: **off**
 - `failglob` (`shopt -s`/`-u`) - When enabled, a glob pattern matching nothing causes an error. Default: **off**
@@ -938,6 +977,10 @@ const $ = build$({
       .questionGlob(),
 });
 ```
+
+### Windows command resolution (PATHEXT)
+
+On Windows, path-like commands (for example, `./tool` or `../bin/tool`) are resolved against `PATHEXT`, so `./tool` will find `tool.exe`, `tool.bat`, etc., without you having to spell out the extension.
 
 ### Cross-platform shebang support
 

--- a/deno.json
+++ b/deno.json
@@ -33,7 +33,7 @@
   "exports": "./mod.ts",
   "imports": {
     "@david/console-static-text": "jsr:@david/console-static-text@^0.3.1",
-    "@david/shell": "jsr:@david/shell@^0.1",
+    "@david/shell": "jsr:@david/shell@^0.2",
     "@deno/dnt": "jsr:@deno/dnt@^0.42.3",
     "@david/path": "jsr:@david/path@^0.3.1",
     "@std/assert": "jsr:@std/assert@1",

--- a/deno.lock
+++ b/deno.lock
@@ -1,47 +1,38 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@david/console-static-text@~0.3.1": "0.3.1",
     "jsr:@david/path@0.3": "0.3.1",
     "jsr:@david/path@~0.3.1": "0.3.1",
-    "jsr:@david/shell@0.1": "0.1.0",
+    "jsr:@david/shell@0.2": "0.2.0",
     "jsr:@david/which-runtime@~0.2.1": "0.2.1",
-    "jsr:@david/which@~0.5.1": "0.5.1",
-    "jsr:@david/which@~0.5.2": "0.5.2",
-    "jsr:@deno/dnt@~0.42.3": "0.42.3",
+    "jsr:@david/which@0.6": "0.6.0",
+    "jsr:@david/which@~0.5.1": "0.5.2",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/async@1": "1.0.16",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/fmt@1": "1.0.10",
-    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/io@0.225": "0.225.3",
     "jsr:@std/path@1": "1.1.4",
-    "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
-    "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@types/node@*": "22.15.15",
     "npm:esbuild@0.20.0": "0.20.0"
   },
   "jsr": {
-    "@david/code-block-writer@13.0.3": {
-      "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
-    },
     "@david/console-static-text@0.3.1": {
       "integrity": "6ad500e3deb72f62e058209537f271a001605d5236e2c1c25e86d89adb3568c3"
     },
     "@david/path@0.3.1": {
       "integrity": "25e31e27ba87832af880e103807afb698548069ab14a274a64d553f45bd49393"
     },
-    "@david/shell@0.1.0": {
-      "integrity": "330c81893e2007dccdad6eaefce72de0dd31297b5aa1771d2e9bc047bcc4c834",
+    "@david/shell@0.2.0": {
+      "integrity": "9967bf95410d8fa69432adebeb6e033b8ec4c7359e362ee5c10c06af05120fae",
       "dependencies": [
         "jsr:@david/path@0.3",
-        "jsr:@david/which@~0.5.2",
+        "jsr:@david/which@0.6",
         "jsr:@std/fmt",
         "jsr:@std/io",
-        "jsr:@std/path@1"
+        "jsr:@std/path"
       ]
     },
     "@david/which@0.5.1": {
@@ -50,18 +41,11 @@
     "@david/which@0.5.2": {
       "integrity": "cd284a87aecdb8e32a5b91a024813fb57cbb8b4889df7d1c90351f073a4301a9"
     },
+    "@david/which@0.6.0": {
+      "integrity": "efe63f07f6741b12b0d470a660f5c20dedf0af0e0c18b5c934d8a930bcaba4bf"
+    },
     "@david/which-runtime@0.2.1": {
       "integrity": "2a304e36b1122ebfe384d45de8fe0fb2bfe54a0a5a2a596efbfc81f54a47a62d"
-    },
-    "@deno/dnt@0.42.3": {
-      "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
-      "dependencies": [
-        "jsr:@david/code-block-writer",
-        "jsr:@std/fmt",
-        "jsr:@std/fs",
-        "jsr:@std/path@1",
-        "jsr:@ts-morph/bootstrap"
-      ]
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -87,13 +71,6 @@
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
-    "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
-      "dependencies": [
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.4"
-      ]
-    },
     "@std/internal@1.0.6": {
       "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
     },
@@ -116,19 +93,6 @@
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
         "jsr:@std/internal"
-      ]
-    },
-    "@ts-morph/bootstrap@0.27.0": {
-      "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
-      "dependencies": [
-        "jsr:@ts-morph/common"
-      ]
-    },
-    "@ts-morph/common@0.27.0": {
-      "integrity": "c7b73592d78ce8479b356fd4f3d6ec3c460d77753a8680ff196effea7a939052",
-      "dependencies": [
-        "jsr:@std/fs",
-        "jsr:@std/path@1"
       ]
     }
   },
@@ -292,7 +256,7 @@
     "dependencies": [
       "jsr:@david/console-static-text@~0.3.1",
       "jsr:@david/path@~0.3.1",
-      "jsr:@david/shell@0.1",
+      "jsr:@david/shell@0.2",
       "jsr:@david/which-runtime@~0.2.1",
       "jsr:@david/which@~0.5.1",
       "jsr:@deno/dnt@~0.42.3",

--- a/deno.lock
+++ b/deno.lock
@@ -1,29 +1,39 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@david/console-static-text@~0.3.1": "0.3.1",
-    "jsr:@david/path@0.3": "0.3.1",
-    "jsr:@david/path@~0.3.1": "0.3.1",
+    "jsr:@david/path@0.3": "0.3.2",
+    "jsr:@david/path@~0.3.1": "0.3.2",
     "jsr:@david/shell@0.2": "0.2.0",
     "jsr:@david/which-runtime@~0.2.1": "0.2.1",
     "jsr:@david/which@0.6": "0.6.0",
     "jsr:@david/which@~0.5.1": "0.5.2",
+    "jsr:@deno/dnt@~0.42.3": "0.42.3",
     "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/async@1": "1.0.16",
+    "jsr:@std/async@1": "1.3.0",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/data-structures@^1.0.11": "1.0.11",
     "jsr:@std/fmt@1": "1.0.10",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/io@0.225": "0.225.3",
     "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
+    "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@types/node@*": "22.15.15",
     "npm:esbuild@0.20.0": "0.20.0"
   },
   "jsr": {
+    "@david/code-block-writer@13.0.3": {
+      "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
+    },
     "@david/console-static-text@0.3.1": {
       "integrity": "6ad500e3deb72f62e058209537f271a001605d5236e2c1c25e86d89adb3568c3"
     },
-    "@david/path@0.3.1": {
-      "integrity": "25e31e27ba87832af880e103807afb698548069ab14a274a64d553f45bd49393"
+    "@david/path@0.3.2": {
+      "integrity": "f25aaa3de4d3b9edfe25ca5edf15e3014fee7df4f77d64327e5300c27c1a0497"
     },
     "@david/shell@0.2.0": {
       "integrity": "9967bf95410d8fa69432adebeb6e033b8ec4c7359e362ee5c10c06af05120fae",
@@ -32,7 +42,7 @@
         "jsr:@david/which@0.6",
         "jsr:@std/fmt",
         "jsr:@std/io",
-        "jsr:@std/path"
+        "jsr:@std/path@1"
       ]
     },
     "@david/which@0.5.1": {
@@ -47,6 +57,16 @@
     "@david/which-runtime@0.2.1": {
       "integrity": "2a304e36b1122ebfe384d45de8fe0fb2bfe54a0a5a2a596efbfc81f54a47a62d"
     },
+    "@deno/dnt@0.42.3": {
+      "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
+      "dependencies": [
+        "jsr:@david/code-block-writer",
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/path@1",
+        "jsr:@ts-morph/bootstrap"
+      ]
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
@@ -56,8 +76,11 @@
     "@std/async@1.0.13": {
       "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
     },
-    "@std/async@1.0.16": {
-      "integrity": "6c9e43035313b67b5de43e2b3ee3eadb39a488a0a0a3143097f112e025d3ee9a"
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9",
+      "dependencies": [
+        "jsr:@std/data-structures"
+      ]
     },
     "@std/bytes@1.0.5": {
       "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
@@ -65,11 +88,21 @@
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
+    },
     "@std/fmt@1.0.7": {
       "integrity": "2a727c043d8df62cd0b819b3fb709b64dd622e42c3b1bb817ea7e6cc606360fb"
     },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
+      ]
     },
     "@std/internal@1.0.6": {
       "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
@@ -93,6 +126,19 @@
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
         "jsr:@std/internal"
+      ]
+    },
+    "@ts-morph/bootstrap@0.27.0": {
+      "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
+      "dependencies": [
+        "jsr:@ts-morph/common"
+      ]
+    },
+    "@ts-morph/common@0.27.0": {
+      "integrity": "c7b73592d78ce8479b356fd4f3d6ec3c460d77753a8680ff196effea7a939052",
+      "dependencies": [
+        "jsr:@std/fs",
+        "jsr:@std/path@1"
       ]
     }
   },


### PR DESCRIPTION
* fix: improve stack traces on error https://github.com/dsherret/shell/pull/1
* feat: add `linesIter()` https://github.com/dsherret/shell/pull/3
* feat: resolve path-like commands with `PATHEXT` on Windows https://github.com/dsherret/shell/pull/4
* feat(BREAKING): support multiline commands and `set +e` https://github.com/dsherret/shell/pull/5

Supporting multiline commands is breaking because previously the parser treated it like any whitespace.


Closes https://github.com/dsherret/dax/issues/303
Closes https://github.com/dsherret/dax/issues/281
Closes https://github.com/dsherret/dax/issues/250
Closes https://github.com/dsherret/dax/issues/150
