### PR TITLE
fix: support interactive prompts when stdin is piped via `/dev/tty` / `CONIN$` fallback

### DIFF
--- a/src/console/ttyFallback.ts
+++ b/src/console/ttyFallback.ts
@@ -1,0 +1,69 @@
+import * as fs from "node:fs";
+import * as tty from "node:tty";
+import process from "node:process";
+
+/** A stdin-shaped handle backed by `/dev/tty` (Unix) or `\\.\CONIN$`
+ * (Windows), so prompts can read keystrokes from the controlling
+ * terminal even when the process's stdin is a pipe.
+ *
+ * Mirrors fzf / vim / `git commit`'s behavior of bypassing stdin and
+ * reading the user's actual terminal directly. */
+export interface TtyStdin {
+  read(p: Uint8Array): Promise<number | null>;
+  setRaw(mode: boolean): void;
+}
+
+interface OpenedTty {
+  fd: number;
+  stream: tty.ReadStream;
+}
+
+// undefined = not yet attempted; null = attempted and failed
+let cached: OpenedTty | null | undefined;
+
+function tryOpen(): OpenedTty | null {
+  if (cached !== undefined) return cached;
+  try {
+    const path = process.platform === "win32" ? "\\\\.\\CONIN$" : "/dev/tty";
+    // r+ rather than r — setRawMode needs the fd to support tcsetattr,
+    // and on some platforms that's only granted when opened for writing too.
+    const fd = fs.openSync(path, "r+");
+    // wrap once for setRawMode access. left in paused mode (the default)
+    // so it doesn't pull bytes out from under fs.read on the same fd —
+    // same pattern dax already relies on with process.stdin.
+    const stream = new tty.ReadStream(fd);
+    cached = { fd, stream };
+  } catch {
+    cached = null;
+  }
+  return cached;
+}
+
+/** Whether a controlling terminal is reachable via `/dev/tty` / `CONIN$`. */
+export function hasFallbackTty(): boolean {
+  return tryOpen() != null;
+}
+
+/** Lazily-opened stdin bound to the controlling terminal. Throws on
+ * use if no controlling terminal is available — guard with
+ * {@link hasFallbackTty} first. */
+export const ttyStdin: TtyStdin = {
+  read(p: Uint8Array): Promise<number | null> {
+    return new Promise((resolve, reject) => {
+      const handle = tryOpen();
+      if (handle == null) {
+        reject(new Error("No controlling terminal available."));
+        return;
+      }
+      fs.read(handle.fd, p, 0, p.length, null, (err, bytesRead) => {
+        if (err) reject(err);
+        else resolve(bytesRead === 0 ? null : bytesRead);
+      });
+    });
+  },
+  setRaw(mode: boolean): void {
+    const handle = tryOpen();
+    if (handle == null) return;
+    handle.stream.setRawMode(mode);
+  },
+};

--- a/src/console/utils.ts
+++ b/src/console/utils.ts
@@ -1,8 +1,19 @@
 import { logger, LoggerRefreshItemKind } from "./logger.ts";
 import { maybeConsoleSize, stripAnsiCodes, type TextItem } from "@david/console-static-text";
 import { stderr, stdin } from "@david/shell";
+import { hasFallbackTty, ttyStdin } from "./ttyFallback.ts";
 
 const encoder = new TextEncoder();
+
+/** Input source for an interactive prompt — either the process's stdin
+ * or a fallback handle on `/dev/tty` / `CONIN$` when stdin is piped. */
+type PromptInput = Pick<typeof stdin, "read" | "setRaw">;
+
+function resolvePromptInput(): PromptInput | undefined {
+  if (isTerminal(stdin)) return stdin;
+  if (hasFallbackTty()) return ttyStdin;
+  return undefined;
+}
 
 export enum Keys {
   Up,
@@ -14,8 +25,8 @@ export enum Keys {
   Backspace,
 }
 
-export async function* readKeys() {
-  return yield* innerReadKeys(stdin);
+export async function* readKeys(reader: PromptInput = stdin) {
+  return yield* innerReadKeys(reader);
 }
 
 export async function* innerReadKeys(reader: Pick<typeof stdin, "read">) {
@@ -140,16 +151,20 @@ export interface SelectionOptions<TReturn> {
 }
 
 export function createSelection<TReturn>(options: SelectionOptions<TReturn>): Promise<TReturn | undefined> {
-  if (!isOutputTty || !isTerminal(stdin)) {
+  // stderr being a tty still gates prompts — that's where the UI is rendered.
+  // for stdin we fall back to /dev/tty (or CONIN$ on Windows) when the
+  // process's stdin is a pipe, so prompts work in `cmd | script.ts`.
+  const input = isOutputTty ? resolvePromptInput() : undefined;
+  if (input == null) {
     throw new Error(`Cannot prompt when not a tty. (Prompt: '${options.message}')`);
   }
   if (maybeConsoleSize() == null) {
     throw new Error(`Cannot prompt when can't get console size. (Prompt: '${options.message}')`);
   }
-  return ensureSingleSelection(async () => {
+  return ensureSingleSelection(input, async () => {
     logger.setItems(LoggerRefreshItemKind.Selection, options.render());
 
-    for await (const key of readKeys()) {
+    for await (const key of readKeys(input)) {
       const keyResult = options.onKey(key);
       if (keyResult != null) {
         const size = {
@@ -171,7 +186,7 @@ export function createSelection<TReturn>(options: SelectionOptions<TReturn>): Pr
 }
 
 let lastPromise: Promise<any> = Promise.resolve();
-function ensureSingleSelection<TReturn>(action: () => Promise<TReturn>) {
+function ensureSingleSelection<TReturn>(input: PromptInput, action: () => Promise<TReturn>) {
   const currentLastPromise = lastPromise;
   const currentPromise = (async () => {
     try {
@@ -181,11 +196,11 @@ function ensureSingleSelection<TReturn>(action: () => Promise<TReturn>) {
     }
     hideCursor();
     try {
-      stdin.setRaw(true);
+      input.setRaw(true);
       try {
         return await action();
       } finally {
-        stdin.setRaw(false);
+        input.setRaw(false);
       }
     } finally {
       showCursor();

--- a/src/test/output-visual-inspection.ts
+++ b/src/test/output-visual-inspection.ts
@@ -38,6 +38,34 @@ $.log("Welcome to the visual test of the progress bars.");
 }
 
 {
+  $.log(
+    "Next: a prompt in a child process whose stdin is a pipe — should still respond to typed keys via the /dev/tty / CONIN$ fallback.",
+  );
+  await delay(1_000);
+
+  const modUrl = import.meta.resolve("../../mod.ts");
+  const childScript = `
+import $ from ${JSON.stringify(modUrl)};
+// drain the piped stdin so the parent's writer can close cleanly —
+// the prompt itself should *not* read these bytes, it should read
+// keystrokes from the controlling terminal via the fallback.
+const piped = await new Response(process.stdin).text();
+console.error("[child] piped stdin contained:", JSON.stringify(piped));
+const choice = await $.select({
+  message: "Pick one (child has piped stdin — type into your terminal)",
+  options: ["alpha", "beta", "gamma"],
+});
+console.error("[child] selected:", choice.value);
+`;
+
+  // pipe benign data so stdin is a non-TTY pipe; the prompt should
+  // bypass it entirely and read keys from the controlling terminal.
+  await $`deno eval ${childScript}`.stdinText("piped data, not keystrokes\n");
+
+  $.log("TTY fallback prompt complete.");
+}
+
+{
   $.log("The text below should show for a bit and then disappear.");
   using scope = staticText.createScope();
   const endTime = Date.now() + 1000;


### PR DESCRIPTION
Closes https://github.com/dsherret/dax/issues/290